### PR TITLE
[Refactor] 공통 네트워크 인스턴스(ApiClient) + AuthSession/TokenStorage + AppScope/Provider 주입 구조 도입

### DIFF
--- a/lib/app_scope.dart
+++ b/lib/app_scope.dart
@@ -1,0 +1,22 @@
+import 'package:inninglog/feature/community/repositories/post_repository.dart';
+import 'package:inninglog/shared/auth/token_storage.dart';
+import 'package:inninglog/shared/network/api_client.dart';
+
+class AppScope {
+  final TokenStorage tokenStorage;
+  final ApiClient apiClient;
+
+  late final CommunityPostRepository communityPostRepository =
+      CommunityPostRepository(apiClient.dio);
+
+  AppScope._({required this.tokenStorage, required this.apiClient});
+
+  static Future<AppScope> create() async {
+    final tokenStorage = SharedPrefsTokenStorage();
+    final apiClient = ApiClient(
+      baseUrl: 'https://api.inninglog.shop',
+      tokenStorage: tokenStorage,
+    );
+    return AppScope._(tokenStorage: tokenStorage, apiClient: apiClient);
+  }
+}

--- a/lib/feature/community/model/community_post.dart
+++ b/lib/feature/community/model/community_post.dart
@@ -1,0 +1,52 @@
+class CommunityPost {
+  final int id;
+  final String teamCode; // ALL, LG, ...
+  final String title;
+  final String content;
+  final String? authorNickname;
+  final int? likeCount;
+  final int? commentCount;
+  final DateTime? createdAt;
+
+  CommunityPost({
+    required this.id,
+    required this.teamCode,
+    required this.title,
+    required this.content,
+    this.authorNickname,
+    this.likeCount,
+    this.commentCount,
+    this.createdAt,
+  });
+
+  factory CommunityPost.fromJson(Map<String, dynamic> json) {
+    int asInt(dynamic v) => v is int ? v : int.tryParse('$v') ?? 0;
+    String asString(dynamic v) => (v ?? '').toString();
+
+    DateTime? parseDate(dynamic v) {
+      if (v == null) return null;
+      return DateTime.tryParse(v.toString());
+    }
+
+    return CommunityPost(
+      id: asInt(json['postId'] ?? json['id']),
+      teamCode: asString(
+        json['teamCode'] ?? json['boardCode'] ?? json['team_code'],
+      ),
+      title: asString(json['title']),
+      content: asString(json['content'] ?? json['body']),
+      authorNickname:
+          (json['authorNickname'] ?? json['nickname'] ?? json['writerNickname'])
+              ?.toString(),
+      likeCount:
+          (json['likeCount'] ?? json['like_count']) == null
+              ? null
+              : asInt(json['likeCount'] ?? json['like_count']),
+      commentCount:
+          (json['commentCount'] ?? json['comment_count']) == null
+              ? null
+              : asInt(json['commentCount'] ?? json['comment_count']),
+      createdAt: parseDate(json['createdAt'] ?? json['created_at']),
+    );
+  }
+}

--- a/lib/feature/community/model/create_post_request.dart
+++ b/lib/feature/community/model/create_post_request.dart
@@ -1,0 +1,58 @@
+class ImageCreateReqDto {
+  final int sequence;
+  final String key;
+
+  const ImageCreateReqDto({required this.sequence, required this.key});
+
+  factory ImageCreateReqDto.fromJson(Map<String, dynamic> json) {
+    return ImageCreateReqDto(
+      sequence: json['sequence'] as int,
+      key: json['key'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {'sequence': sequence, 'key': key};
+}
+
+class CreatePostRequest {
+  final String title;
+  final String content;
+  final List<ImageCreateReqDto> imageCreateReqDto;
+
+  const CreatePostRequest({
+    required this.title,
+    required this.content,
+    this.imageCreateReqDto = const [],
+  });
+
+  factory CreatePostRequest.fromJson(Map<String, dynamic> json) {
+    return CreatePostRequest(
+      title: json['title'] as String,
+      content: json['content'] as String,
+      imageCreateReqDto:
+          (json['imageCreateReqDto'] as List<dynamic>? ?? const [])
+              .whereType<Map<String, dynamic>>()
+              .map(ImageCreateReqDto.fromJson)
+              .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'title': title,
+    'content': content,
+    'imageCreateReqDto': imageCreateReqDto.map((e) => e.toJson()).toList(),
+  };
+
+  /// 이미지 없이 쓰기 편한 헬퍼(선택)
+  CreatePostRequest copyWith({
+    String? title,
+    String? content,
+    List<ImageCreateReqDto>? imageCreateReqDto,
+  }) {
+    return CreatePostRequest(
+      title: title ?? this.title,
+      content: content ?? this.content,
+      imageCreateReqDto: imageCreateReqDto ?? this.imageCreateReqDto,
+    );
+  }
+}

--- a/lib/feature/community/repositories/post_repository.dart
+++ b/lib/feature/community/repositories/post_repository.dart
@@ -1,0 +1,26 @@
+import 'package:dio/dio.dart';
+import '../../../shared/network/api_envelope.dart';
+import '../model/create_post_request.dart';
+
+class CommunityPostRepository {
+  final Dio _dio;
+  CommunityPostRepository(this._dio);
+
+  /// 커뮤니티 글 작성
+  /// 응답 스펙: { code: string, message: string, data: {} }
+  Future<ApiEnvelope> createPost({
+    required String teamCode,
+    required CreatePostRequest request,
+  }) async {
+    final res = await _dio.post(
+      '/community/$teamCode/posts/create',
+      data: request.toJson(),
+    );
+
+    final json = res.data;
+    if (json is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected response shape');
+    }
+    return ApiEnvelope.fromJson(json);
+  }
+}

--- a/lib/feature/community/screens/writing_post_page.dart
+++ b/lib/feature/community/screens/writing_post_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:inninglog/app_scope.dart';
 import 'package:inninglog/feature/community/data/team_catalog.dart';
 import 'package:inninglog/feature/community/viewmodel/writing_post_view_model.dart';
 import 'package:inninglog/feature/community/widgets/writing_post/image_attachment_bar.dart';
@@ -7,184 +8,179 @@ import 'package:inninglog/feature/community/widgets/writing_post/writing_post_ap
 import 'package:inninglog/feature/community/widgets/writing_post/writing_post_guidelines_footer.dart';
 import 'package:inninglog/shared/service/image_pick_service.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:provider/provider.dart';
 
-class WritingPostPage extends StatefulWidget {
+class WritingPostPage extends StatelessWidget {
   final String teamCode;
   const WritingPostPage({super.key, required this.teamCode});
 
   @override
-  State<WritingPostPage> createState() => _WritingPostPageState();
+  Widget build(BuildContext context) {
+    final repo = context.read<AppScope>().communityPostRepository;
+
+    return ChangeNotifierProvider<WritingPostViewModel>(
+      create:
+          (_) => WritingPostViewModel(
+            maxImages: 5,
+            imagePickService: ImagePickService(),
+            repo: repo,
+          ),
+      child: _WritingPostView(teamCode: teamCode),
+    );
+  }
 }
 
-class _WritingPostPageState extends State<WritingPostPage> {
-  late final vm = WritingPostViewModel(
-    maxImages: 5,
-    imagePickService: ImagePickService(),
-  );
+class _WritingPostView extends StatelessWidget {
+  final String teamCode;
+  const _WritingPostView({required this.teamCode});
 
-  @override
-  void dispose() {
-    vm.dispose();
-    super.dispose();
-  }
-
-  void _submit() {
-    vm.submitDraft(); // TODO: 등록 API 연동
+  void _submit(BuildContext context, WritingPostViewModel vm) {
+    vm.submit(teamCode: teamCode); // TODO: 등록 API 연동 시 vm.submit()로 변경
     Navigator.of(context).pop();
   }
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: vm,
-      builder: (context, _) {
-        final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final vm = context.watch<WritingPostViewModel>();
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
 
-        return Scaffold(
-          // 키보드 올라오면 body/bottomNavigationBar가 같이 위로 올라가게
-          resizeToAvoidBottomInset: true,
-          backgroundColor: Colors.white,
+    return Scaffold(
+      resizeToAvoidBottomInset: true,
+      backgroundColor: Colors.white,
 
-          body: SafeArea(
-            bottom: false, // bottom은 bottomNavigationBar에서 처리
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+      body: SafeArea(
+        bottom: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              WritingPostAppBar(
+                teamLabel: kboTeamLabelOf(teamCode),
+                onClose: () => Navigator.of(context).pop(),
+                onSubmit: () => _submit(context, vm),
+                isSubmitEnabled: vm.canSubmit,
+              ),
+              const SizedBox(height: 12),
 
-                children: [
-                  WritingPostAppBar(
-                    teamLabel: kboTeamLabelOf(widget.teamCode),
-                    onClose: () => Navigator.of(context).pop(),
-                    onSubmit: _submit,
-                    isSubmitEnabled: vm.canSubmit,
-                  ),
-                  const SizedBox(height: 12),
-
-                  // 제목 (고정)
-                  AnimatedContainer(
-                    duration: const Duration(milliseconds: 160),
-                    curve: Curves.easeOut,
-                    padding: const EdgeInsets.only(bottom: 8),
-
-                    decoration: BoxDecoration(
-                      border: Border(
-                        bottom: BorderSide(
-                          color:
-                              vm.isTitleFocused
-                                  ? AppColors.gray400
-                                  : Colors.transparent,
-                          width: 1,
-                        ),
-                      ),
+              // 제목
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 160),
+                curve: Curves.easeOut,
+                padding: const EdgeInsets.only(bottom: 8),
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      color:
+                          vm.isTitleFocused
+                              ? AppColors.gray400
+                              : Colors.transparent,
+                      width: 1,
                     ),
-                    child: TextField(
-                      controller: vm.titleController,
-                      focusNode: vm.titleFocusNode,
-                      textInputAction: TextInputAction.next,
-                      onTapOutside:
-                          (_) => FocusManager.instance.primaryFocus?.unfocus(),
-                      inputFormatters: [LengthLimitingTextInputFormatter(20)],
-                      style: const TextStyle(
-                        fontSize: 22,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.gray900,
+                  ),
+                ),
+                child: TextField(
+                  controller: vm.titleController,
+                  focusNode: vm.titleFocusNode,
+                  textInputAction: TextInputAction.next,
+                  onTapOutside:
+                      (_) => FocusManager.instance.primaryFocus?.unfocus(),
+                  inputFormatters: [LengthLimitingTextInputFormatter(20)],
+                  style: const TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.gray900,
+                    fontFamily: 'Pretendard',
+                  ),
+                  decoration: const InputDecoration(
+                    hintText: '제목을 입력해주세요.',
+                    hintStyle: TextStyle(
+                      fontSize: 22,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.gray600,
+                      fontFamily: 'Pretendard',
+                    ),
+                    border: InputBorder.none,
+                    isDense: true,
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                  onSubmitted: (_) => FocusScope.of(context).nextFocus(),
+                ),
+              ),
+              const SizedBox(height: 10),
+
+              // 본문 (스크롤 영역)
+              Expanded(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () => vm.bodyFocusNode.requestFocus(),
+                  child: TextField(
+                    controller: vm.bodyController,
+                    focusNode: vm.bodyFocusNode,
+                    onTapOutside:
+                        (_) => FocusManager.instance.primaryFocus?.unfocus(),
+                    inputFormatters: [LengthLimitingTextInputFormatter(1500)],
+                    expands: true,
+                    maxLines: null,
+                    textAlignVertical: TextAlignVertical.top,
+                    keyboardType: TextInputType.multiline,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w400,
+                      color: AppColors.gray900,
+                      fontFamily: 'Pretendard',
+                    ),
+                    decoration: const InputDecoration(
+                      hintText: '내용을 입력하세요.',
+                      hintStyle: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w400,
+                        color: AppColors.gray600,
                         fontFamily: 'Pretendard',
                       ),
-                      decoration: const InputDecoration(
-                        hintText: '제목을 입력해주세요.',
-                        hintStyle: TextStyle(
-                          fontSize: 22,
-                          fontWeight: FontWeight.w600,
-                          color: AppColors.gray600,
-                          fontFamily: 'Pretendard',
-                        ),
-                        border: InputBorder.none,
-                        isDense: true,
-                        contentPadding: EdgeInsets.zero,
-                      ),
-                      onSubmitted: (_) => FocusScope.of(context).nextFocus(),
+                      border: InputBorder.none,
+                      isDense: true,
+                      contentPadding: EdgeInsets.zero,
                     ),
                   ),
-                  const SizedBox(height: 10),
-
-                  // 본문 (여기만 스크롤)
-                  Expanded(
-                    child: GestureDetector(
-                      behavior: HitTestBehavior.opaque,
-                      onTap: () => vm.bodyFocusNode.requestFocus(),
-                      child: TextField(
-                        controller: vm.bodyController,
-                        focusNode: vm.bodyFocusNode,
-                        onTapOutside:
-                            (_) =>
-                                FocusManager.instance.primaryFocus?.unfocus(),
-                        inputFormatters: [
-                          LengthLimitingTextInputFormatter(1500),
-                        ],
-                        expands: true,
-                        maxLines: null,
-                        textAlignVertical: TextAlignVertical.top,
-                        keyboardType: TextInputType.multiline,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w400,
-                          color: AppColors.gray900,
-                          fontFamily: 'Pretendard',
-                        ),
-                        decoration: const InputDecoration(
-                          hintText: '내용을 입력하세요.',
-                          hintStyle: TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w400,
-                            color: AppColors.gray600,
-                            fontFamily: 'Pretendard',
-                          ),
-                          border: InputBorder.none,
-                          isDense: true,
-                          contentPadding: EdgeInsets.zero,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
+                ),
               ),
-            ),
+            ],
           ),
+        ),
+      ),
 
-          // 바닥 고정 영역 (가이드라인 + 첨부바)
-          bottomNavigationBar: SafeArea(
-            top: false,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (bottomInset > 0)
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: IconButton(
-                        icon: const Icon(Icons.keyboard_hide),
-                        tooltip: '키보드 내리기',
-                        onPressed:
-                            () => FocusManager.instance.primaryFocus?.unfocus(),
-                      ),
-                    ),
-                  const SizedBox(height: 24),
-                  WritingPostGuidelinesFooter(),
-                  const SizedBox(height: 24),
-                  ImageAttachmentBar(
-                    images: vm.images,
-                    maxImages: vm.maxImages,
-                    onPickImages: vm.canPickMore ? vm.pickFromGallery : null,
-                    onRemoveImageAt: vm.removeImageAt,
+      // 바닥 고정 영역
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (bottomInset > 0)
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: IconButton(
+                    icon: const Icon(Icons.keyboard_hide),
+                    tooltip: '키보드 내리기',
+                    onPressed:
+                        () => FocusManager.instance.primaryFocus?.unfocus(),
                   ),
-                ],
+                ),
+              const SizedBox(height: 24),
+              WritingPostGuidelinesFooter(),
+              const SizedBox(height: 24),
+              ImageAttachmentBar(
+                images: vm.images,
+                maxImages: vm.maxImages,
+                onPickImages: vm.canPickMore ? vm.pickFromGallery : null,
+                onRemoveImageAt: vm.removeImageAt,
               ),
-            ),
+            ],
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/lib/feature/community/viewmodel/writing_post_view_model.dart
+++ b/lib/feature/community/viewmodel/writing_post_view_model.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:inninglog/app_scope.dart';
+import 'package:inninglog/feature/community/model/create_post_request.dart';
+import 'package:inninglog/feature/community/repositories/post_repository.dart';
 import 'package:inninglog/shared/service/image_pick_service.dart';
 
 class WritingPostViewModel extends ChangeNotifier {
@@ -13,6 +16,8 @@ class WritingPostViewModel extends ChangeNotifier {
   final List<ImageProvider> _images = [];
   List<ImageProvider> get images => List.unmodifiable(_images);
 
+  final CommunityPostRepository repo;
+
   bool _isPicking = false;
   bool get isPicking => _isPicking;
 
@@ -25,7 +30,11 @@ class WritingPostViewModel extends ChangeNotifier {
   bool get canPickMore => _images.length < maxImages;
   bool get canSubmit => _isFormFilled;
 
-  WritingPostViewModel({required this.imagePickService, this.maxImages = 5}) {
+  WritingPostViewModel({
+    required this.imagePickService,
+    this.maxImages = 5,
+    required this.repo,
+  }) {
     titleController.addListener(_handleTextChanged);
     bodyController.addListener(_handleTextChanged);
     titleFocusNode.addListener(_handleTitleFocusChanged);
@@ -56,6 +65,31 @@ class WritingPostViewModel extends ChangeNotifier {
     debugPrint('  title: "$title"');
     debugPrint('  body: "$body"');
     debugPrint('  imageCount: ${_images.length}');
+  }
+
+  Future<void> submit({required String teamCode}) async {
+    // submitting = true;
+    // error = null;
+    notifyListeners();
+    final title = titleController.text.trim();
+    final content = bodyController.text.trim();
+
+    try {
+      await repo.createPost(
+        teamCode: teamCode,
+        request: CreatePostRequest(
+          title: title,
+          content: content,
+          imageCreateReqDto: [],
+        ),
+      );
+    } catch (e) {
+      debugPrint(e.toString());
+      // error = e.toString();
+    } finally {
+      // submitting = false;
+      notifyListeners();
+    }
   }
 
   void removeImageAt(int index) {

--- a/lib/feature/login/models/KakaoLoginWebViewPage.dart
+++ b/lib/feature/login/models/KakaoLoginWebViewPage.dart
@@ -1,43 +1,14 @@
-// lib/screens/kakao_login_webview_page.dart
 import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:webview_flutter/webview_flutter.dart';
 import 'package:go_router/go_router.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:http/http.dart' as http;
-
-/// JWT payload 확인용 (디버깅)
-String _decodeJwtPayload(String jwt) {
-  try {
-    final parts = jwt.split('.');
-    if (parts.length != 3) return '(not a JWT)';
-    String normalize(String s) =>
-        s.padRight(s.length + (4 - s.length % 4) % 4, '=')
-            .replaceAll('-', '+').replaceAll('_', '/');
-    final payload = utf8.decode(base64Url.decode(normalize(parts[1])));
-    return payload; // JSON string
-  } catch (_) {
-    return '(decode failed)';
-  }
-}
-
-/// JWT에서 memberId 추출: `memberId`가 우선, 없으면 `sub`
-int? _extractMemberId(String jwt) {
-  try {
-    final parts = jwt.split('.');
-    if (parts.length != 3) return null;
-    String normalize(String s) =>
-        s.padRight(s.length + (4 - s.length % 4) % 4, '=')
-            .replaceAll('-', '+').replaceAll('_', '/');
-    final payloadJson = utf8.decode(base64Url.decode(normalize(parts[1])));
-    final map = jsonDecode(payloadJson) as Map<String, dynamic>;
-    final v = map['memberId'] ?? map['sub'];
-    if (v == null) return null;
-    return int.tryParse(v.toString());
-  } catch (_) {
-    return null;
-  }
-}
+import 'package:inninglog/app_scope.dart';
+import 'package:inninglog/shared/auth/auth_session.dart';
+import 'package:inninglog/shared/auth/token_storage.dart';
+import 'package:inninglog/shared/utils/jwt_utils.dart';
+import 'package:provider/provider.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
 class KakaoLoginWebViewPage extends StatefulWidget {
   const KakaoLoginWebViewPage({super.key});
@@ -50,152 +21,128 @@ class _KakaoLoginWebViewPageState extends State<KakaoLoginWebViewPage> {
   late final WebViewController _controller;
   bool _loading = true;
 
-  // 중복 실행 방지
-  bool _kakaoAuthLaunched = false; // /login/page → 카카오 URL 이동 여부
-  bool _callbackHandled = false;   // /callback 처리 완료 여부
+  bool _kakaoAuthLaunched = false;
+  bool _callbackHandled = false;
+
+  static const _base = 'https://api.inninglog.shop';
+  late final _scope = context.read<AppScope>();
 
   @override
   void initState() {
     super.initState();
 
-    _controller = WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setBackgroundColor(const Color(0x00000000))
-      ..setNavigationDelegate(
-        NavigationDelegate(
-          onPageStarted: (url) {
-            _log('[WEBVIEW] onPageStarted: $url');
-            setState(() => _loading = true);
-          },
-          onWebResourceError: (err) {
-            _log('[WEBVIEW ERROR] $err');
-            _showSnack('웹뷰 오류: ${err.description}');
-          },
-          onPageFinished: (url) async {
-            _log('[WEBVIEW] onPageFinished: $url');
-            setState(() => _loading = false);
+    _controller =
+        WebViewController()
+          ..setJavaScriptMode(JavaScriptMode.unrestricted)
+          ..setBackgroundColor(const Color(0x00000000))
+          ..setNavigationDelegate(
+            NavigationDelegate(
+              onPageStarted: (url) {
+                _log('[WEBVIEW] onPageStarted: $url');
+                if (mounted) setState(() => _loading = true);
+              },
+              onWebResourceError: (err) {
+                _log('[WEBVIEW ERROR] $err');
+                _showSnack('웹뷰 오류: ${err.description}');
+              },
+              onPageFinished: (url) async {
+                _log('[WEBVIEW] onPageFinished: $url');
+                if (mounted) setState(() => _loading = false);
 
-            // 1) /login/page → JSON(location) 파싱 후 카카오 인증 페이지로 이동
-            if (!_kakaoAuthLaunched &&
-                (url == 'https://api.inninglog.shop/login/page' ||
-                    url.startsWith('https://api.inninglog.shop/login/page'))) {
-              try {
-                final jsResult = await _controller
-                    .runJavaScriptReturningResult('document.body.innerText');
-
-                final body = (jsResult as String)
-                    .replaceAll(RegExp(r'^"|"$'), '')
-                    .replaceAll(r'\"', '"');
-
-                _log('[LOGIN PAGE BODY] $body');
-
-                final map = jsonDecode(body) as Map<String, dynamic>;
-                _log('[LOGIN PAGE MAP] $map');
-
-                final location = (map['location'] as String?)?.trim();
-                _log('[LOGIN PAGE LOCATION] $location');
-
-                if (location != null && location.isNotEmpty) {
-                  _kakaoAuthLaunched = true;
-                  await _controller.loadRequest(Uri.parse(location));
-                  return;
-                } else {
-                  _showSnack('location이 비어있습니다.');
-                }
-              } catch (e) {
-                _log('[LOGIN PAGE PARSE ERROR] $e');
-                _showSnack('로그인 URL 파싱 실패: $e');
-              }
-            }
-
-            // 2) /callback → 바디(JSON)에서 토큰/닉네임 파싱 → 저장 → (옵션) 프로빙 → 라우팅
-            if (!_callbackHandled &&
-                url.startsWith('https://api.inninglog.shop/callback')) {
-              try {
-                final jsResult = await _controller
-                    .runJavaScriptReturningResult('document.body.innerText');
-
-                final body = (jsResult as String)
-                    .replaceAll(RegExp(r'^"|"$'), '')
-                    .replaceAll(r'\"', '"');
-
-                _log('[CALLBACK BODY RAW] $body');
-
-                final map = jsonDecode(body) as Map<String, dynamic>;
-                _log('[CALLBACK MAP] $map');
-
-                final nickname     = map['nickname']     as String?;
-                final accessToken  = map['accessToken']  as String?;
-                final refreshToken = map['refreshToken'] as String?;
-                final isNewMember  = (map['newMember'] ?? false) as bool;
-
-                _log('[CALLBACK nickname] $nickname');
-                _log('[CALLBACK accessToken] ${accessToken != null ? accessToken.substring(0, accessToken.length > 16 ? 16 : accessToken.length) : 'null'}...');
-                _log('[CALLBACK refreshToken] ${refreshToken != null ? refreshToken.substring(0, refreshToken.length > 16 ? 16 : refreshToken.length) : 'null'}...');
-                _log('[CALLBACK newMember] $isNewMember');
-
-                if (accessToken == null || accessToken.isEmpty) {
-                  _log('[ERROR] accessToken is NULL or EMPTY');
-                  _showSnack('토큰을 찾지 못했습니다.');
+                // 1) /login/page → location 파싱 후 카카오 인증 URL로 이동
+                if (!_kakaoAuthLaunched && _isLoginPage(url)) {
+                  await _handleLoginPage();
                   return;
                 }
 
-                // 디버그: JWT 페이로드
-                final payload = _decodeJwtPayload(accessToken);
-                _log('[CALLBACK TOKEN PAYLOAD] $payload');
-
-                // memberId 추출
-                final memberId = _extractMemberId(accessToken);
-                _log('👤 parsed memberId = $memberId');
-
-                // 저장
-                final prefs = await SharedPreferences.getInstance();
-                await prefs.setString('accessToken', accessToken);
-                if (refreshToken != null) {
-                  await prefs.setString('refreshToken', refreshToken);
+                // 2) /callback → JSON 파싱 → 토큰 저장 → 라우팅
+                if (!_callbackHandled && _isCallback(url)) {
+                  await _handleCallback();
+                  return;
                 }
-                if (nickname != null) {
-                  await prefs.setString('nickname', nickname);
-                }
-                if (memberId != null) {
-                  await prefs.setInt('memberId', memberId);
-                }
-
-                final savedToken = prefs.getString('accessToken');
-                final savedMid   = prefs.getInt('memberId');
-                _log('[TOKEN SAVED] ${savedToken != null ? 'YES' : 'NO'}');
-                _log('[memberId SAVED] ${savedMid ?? 'NO'}');
-
-                // (옵션) 토큰으로 API 프로빙 (인증 유효성 즉시 확인)
-                await _probeWithToken(accessToken);
-
-                // 라우팅
-                _callbackHandled = true;
-                if (!mounted) return;
-                context.go(isNewMember ? '/onboarding6' : '/home');
-              } catch (e) {
-                _log('[CALLBACK PARSE ERROR] $e');
-                _showSnack('콜백 파싱 실패: $e');
-              }
-            }
-          },
-        ),
-      )
-      ..loadRequest(Uri.parse('https://api.inninglog.shop/login/page'));
+              },
+            ),
+          )
+          ..loadRequest(Uri.parse('$_base/login/page'));
   }
 
-  /// 인증 토큰으로 샘플 API 호출 (성공 시 200)
-  Future<void> _probeWithToken(String accessToken) async {
+  bool _isLoginPage(String url) =>
+      url == '$_base/login/page' || url.startsWith('$_base/login/page');
+
+  bool _isCallback(String url) => url.startsWith('$_base/callback');
+
+  Future<void> _handleLoginPage() async {
     try {
-      final resp = await http.get(
-        Uri.parse('https://api.inninglog.shop/home/view'),
-        headers: {'Authorization': 'Bearer $accessToken'},
-      );
-      _log('[PROBE STATUS] ${resp.statusCode}');
-      _log('[PROBE BODY] ${resp.body}');
+      final bodyText = await _readBodyInnerText();
+      _log('[LOGIN PAGE BODY] $bodyText');
+
+      final map = jsonDecode(bodyText) as Map<String, dynamic>;
+      final location = (map['location'] as String?)?.trim();
+
+      _log('[LOGIN PAGE LOCATION] $location');
+
+      if (location != null && location.isNotEmpty) {
+        _kakaoAuthLaunched = true;
+        await _controller.loadRequest(Uri.parse(location));
+      } else {
+        _showSnack('location이 비어있습니다.');
+      }
     } catch (e) {
-      _log('[PROBE ERROR] $e');
+      _log('[LOGIN PAGE PARSE ERROR] $e');
+      _showSnack('로그인 URL 파싱 실패: $e');
     }
+  }
+
+  Future<void> _handleCallback() async {
+    try {
+      final bodyText = await _readBodyInnerText();
+      _log('[CALLBACK BODY] $bodyText');
+
+      final map = jsonDecode(bodyText) as Map<String, dynamic>;
+
+      // 1) callback json → session
+      var session = AuthSession.fromCallbackJson(map);
+
+      // 2) memberId는 JWT에서 추출 (있으면 저장)
+      final memberId = JwtUtils.extractMemberId(session.accessToken);
+      session = session.copyWith(memberId: memberId);
+
+      if (kDebugMode) {
+        _log('[CALLBACK nickname] ${session.nickname}');
+        _log('[CALLBACK newMember] ${session.isNewMember}');
+        _log('[CALLBACK memberId] ${session.memberId}');
+        _log(
+          '[CALLBACK TOKEN PAYLOAD] ${JwtUtils.decodePayload(session.accessToken)}',
+        );
+      }
+
+      // 3) 저장 (SharedPreferences 직접 접근 제거)
+      await _scope.tokenStorage.saveSession(session);
+
+      // 4) (옵션) 토큰 검증이 필요하면 repository 호출로 대체
+      // await widget.homeRepository?.fetchHomeData();
+
+      // 5) 라우팅
+      _callbackHandled = true;
+      if (!mounted) return;
+      context.go(session.isNewMember ? '/onboarding6' : '/home');
+    } catch (e) {
+      _log('[CALLBACK PARSE ERROR] $e');
+      _showSnack('콜백 처리 실패: $e');
+    }
+  }
+
+  /// WebView의 document.body.innerText를 JSON string으로 안전하게 가져오기
+  Future<String> _readBodyInnerText() async {
+    final jsResult = await _controller.runJavaScriptReturningResult(
+      'document.body.innerText',
+    );
+
+    // webview_flutter 환경마다 반환 타입이 달라질 수 있어 안전 처리
+    final raw = jsResult?.toString() ?? '';
+
+    // 기존 코드에서 하던 따옴표/이스케이프 보정 유지
+    return raw.replaceAll(RegExp(r'^"|"$'), '').replaceAll(r'\"', '"');
   }
 
   void _showSnack(String msg) {
@@ -204,10 +151,11 @@ class _KakaoLoginWebViewPageState extends State<KakaoLoginWebViewPage> {
   }
 
   void _log(String msg) {
-    // 긴 문자열도 끊어서 안전하게 출력
     const chunk = 1024;
     for (var i = 0; i < msg.length; i += chunk) {
-      debugPrint(msg.substring(i, (i + chunk > msg.length) ? msg.length : i + chunk));
+      debugPrint(
+        msg.substring(i, (i + chunk > msg.length) ? msg.length : i + chunk),
+      );
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:go_router/go_router.dart';
+import 'package:inninglog/app_scope.dart';
 import 'package:inninglog/router/app_routes.dart';
 import 'package:inninglog/shared/widgets/main_navigation.dart';
 import 'package:inninglog/feature/login/models/KakaoLoginWebViewPage.dart';
@@ -29,6 +30,7 @@ import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:kakao_flutter_sdk_common/kakao_flutter_sdk_common.dart';
 import 'package:amplitude_flutter/amplitude.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:io' show Platform;
 import 'shared/amplitude/analytics.dart';
@@ -49,8 +51,9 @@ Future<void> main() async {
   } else {
     print('⚠️ AMPLITUDE_API_KEY is missing');
   }
+  final scope = await AppScope.create();
 
-  runApp(const InningLogApp());
+  runApp(Provider<AppScope>.value(value: scope, child: const InningLogApp()));
 }
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();

--- a/lib/shared/auth/auth_session.dart
+++ b/lib/shared/auth/auth_session.dart
@@ -1,0 +1,38 @@
+class AuthSession {
+  final String accessToken;
+  final String? refreshToken;
+  final String? nickname;
+  final int? memberId;
+  final bool isNewMember;
+
+  AuthSession({
+    required this.accessToken,
+    this.refreshToken,
+    this.nickname,
+    this.memberId,
+    required this.isNewMember,
+  });
+
+  factory AuthSession.fromCallbackJson(Map<String, dynamic> map) {
+    final accessToken = map['accessToken'] as String?;
+    if (accessToken == null || accessToken.isEmpty) {
+      throw const FormatException('accessToken is missing');
+    }
+
+    return AuthSession(
+      accessToken: accessToken,
+      refreshToken: map['refreshToken'] as String?,
+      nickname: map['nickname'] as String?,
+      isNewMember: (map['newMember'] ?? false) as bool,
+      memberId: null,
+    );
+  }
+
+  AuthSession copyWith({int? memberId}) => AuthSession(
+    accessToken: accessToken,
+    refreshToken: refreshToken,
+    nickname: nickname,
+    isNewMember: isNewMember,
+    memberId: memberId,
+  );
+}

--- a/lib/shared/auth/token_storage.dart
+++ b/lib/shared/auth/token_storage.dart
@@ -1,0 +1,57 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'auth_session.dart';
+
+abstract class TokenStorage {
+  Future<String?> readAccessToken();
+  Future<String?> readRefreshToken();
+
+  Future<void> saveSession(AuthSession session);
+  Future<void> clear();
+}
+
+class SharedPrefsTokenStorage implements TokenStorage {
+  static const _kAccessTokenKey = 'accessToken';
+  static const _kRefreshTokenKey = 'refreshToken';
+  static const _kNicknameKey = 'nickname';
+  static const _kMemberIdKey = 'memberId';
+
+  @override
+  Future<String?> readAccessToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_kAccessTokenKey);
+  }
+
+  @override
+  Future<String?> readRefreshToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_kRefreshTokenKey);
+  }
+
+  @override
+  Future<void> saveSession(AuthSession session) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await prefs.setString(_kAccessTokenKey, session.accessToken);
+
+    if (session.refreshToken != null && session.refreshToken!.isNotEmpty) {
+      await prefs.setString(_kRefreshTokenKey, session.refreshToken!);
+    }
+
+    if (session.nickname != null && session.nickname!.isNotEmpty) {
+      await prefs.setString(_kNicknameKey, session.nickname!);
+    }
+
+    if (session.memberId != null) {
+      await prefs.setInt(_kMemberIdKey, session.memberId!);
+    }
+  }
+
+  @override
+  Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_kAccessTokenKey);
+    await prefs.remove(_kRefreshTokenKey);
+    await prefs.remove(_kNicknameKey);
+    await prefs.remove(_kMemberIdKey);
+  }
+}

--- a/lib/shared/network/api_client.dart
+++ b/lib/shared/network/api_client.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import '../auth/token_storage.dart';
+import 'app_error.dart';
+
+class ApiClient {
+  final Dio dio;
+
+  // 앱 공통 Dio 클라이언트 설정: 기본 옵션 + 인증/로그/에러 매핑 인터셉터 구성
+  ApiClient({required String baseUrl, required TokenStorage tokenStorage})
+    : dio = Dio(
+        BaseOptions(
+          baseUrl: baseUrl,
+          connectTimeout: const Duration(seconds: 10),
+          receiveTimeout: const Duration(seconds: 20),
+          headers: {'Accept': 'application/json'},
+        ),
+      ) {
+    dio.interceptors.add(_AuthInterceptor(tokenStorage));
+
+    if (kDebugMode) {
+      dio.interceptors.add(
+        LogInterceptor(
+          requestBody: true,
+          responseBody: true,
+          requestHeader: true,
+          responseHeader: false,
+        ),
+      );
+    }
+
+    // 에러를 AppError로 통일해 던지도록 (선택)
+    dio.interceptors.add(_ErrorMapInterceptor());
+  }
+}
+
+// 요청마다 저장된 액세스 토큰을 Authorization 헤더에 붙이는 인터셉터
+class _AuthInterceptor extends Interceptor {
+  final TokenStorage tokenStorage;
+  _AuthInterceptor(this.tokenStorage);
+
+  @override
+  void onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    final token = await tokenStorage.readAccessToken();
+    if (token != null && token.isNotEmpty) {
+      options.headers['Authorization'] = 'Bearer $token';
+    }
+    handler.next(options);
+  }
+}
+
+// DioException을 AppError 계층으로 변환해 에러 핸들링을 단순화
+class _ErrorMapInterceptor extends Interceptor {
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    // 이미 AppError로 감싸졌으면 그대로
+    if (err.error is AppError) return handler.next(err);
+
+    final status = err.response?.statusCode;
+    final data = err.response?.data;
+    final msg = _extractMessage(data) ?? err.message ?? '요청에 실패했습니다.';
+
+    AppError mapped;
+    if (err.type == DioExceptionType.connectionTimeout ||
+        err.type == DioExceptionType.receiveTimeout ||
+        err.type == DioExceptionType.sendTimeout) {
+      mapped = NetworkError('네트워크 타임아웃: $msg');
+    } else if (err.type == DioExceptionType.unknown &&
+        err.error is SocketException) {
+      mapped = NetworkError('네트워크 연결 실패');
+    } else if (status == 401) {
+      mapped = const UnauthorizedError();
+    } else if (status == 404) {
+      mapped = const NotFoundError();
+    } else if (status == 400) {
+      mapped = BadRequestError(msg, code: _extractCode(data));
+    } else if (status != null && status >= 500) {
+      mapped = ServerError('서버 오류($status): $msg');
+    } else {
+      mapped = UnknownError(msg);
+    }
+
+    handler.next(err.copyWith(error: mapped));
+  }
+
+  String? _extractMessage(dynamic data) {
+    if (data is Map<String, dynamic>) {
+      final m = data['message'];
+      if (m != null) return m.toString();
+    }
+    return null;
+  }
+
+  String? _extractCode(dynamic data) {
+    if (data is Map<String, dynamic>) {
+      final c = data['code'];
+      if (c != null) return c.toString();
+    }
+    return null;
+  }
+}

--- a/lib/shared/network/api_envelope.dart
+++ b/lib/shared/network/api_envelope.dart
@@ -1,0 +1,19 @@
+class ApiEnvelope {
+  // 공통 API 응답 래퍼: 서버가 내려주는 data/message/code/success를 담는다.
+  final dynamic data;
+  final String? message;
+  final int? code;
+  final bool? success;
+
+  ApiEnvelope({required this.data, this.message, this.code, this.success});
+
+  // JSON 맵을 ApiEnvelope 인스턴스로 변환
+  factory ApiEnvelope.fromJson(Map<String, dynamic> json) {
+    return ApiEnvelope(
+      data: json['data'],
+      message: json['message'] as String?,
+      code: json['code'] is int ? json['code'] as int : null,
+      success: json['success'] is bool ? json['success'] as bool : null,
+    );
+  }
+}

--- a/lib/shared/network/app_error.dart
+++ b/lib/shared/network/app_error.dart
@@ -1,0 +1,44 @@
+sealed class AppError implements Exception {
+  // 네트워크 계층에서 공통으로 사용할 에러 베이스 클래스
+  final String message;
+  const AppError(this.message);
+
+  @override
+  String toString() => '$runtimeType: $message';
+}
+
+// 네트워크 타임아웃/연결 실패 등 네트워크 장애
+class NetworkError extends AppError {
+  const NetworkError(super.message);
+}
+
+// 인증 필요(401)
+class UnauthorizedError extends AppError {
+  const UnauthorizedError([super.message = '인증이 필요합니다.']);
+}
+
+// 리소스 없음(404)
+class NotFoundError extends AppError {
+  const NotFoundError([super.message = '요청한 리소스를 찾을 수 없습니다.']);
+}
+
+// 잘못된 요청(400) — 서버 코드가 함께 올 수 있음
+class BadRequestError extends AppError {
+  final String? code;
+  const BadRequestError(super.message, {this.code});
+}
+
+// 서버 오류(5xx)
+class ServerError extends AppError {
+  const ServerError([super.message = '서버 오류가 발생했습니다.']);
+}
+
+// 응답 파싱 실패
+class ParseError extends AppError {
+  const ParseError([super.message = '응답 파싱에 실패했습니다.']);
+}
+
+// 분류되지 않은 오류
+class UnknownError extends AppError {
+  const UnknownError([super.message = '알 수 없는 오류가 발생했습니다.']);
+}

--- a/lib/shared/utils/jwt_utils.dart
+++ b/lib/shared/utils/jwt_utils.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+class JwtUtils {
+  static String decodePayload(String jwt) {
+    try {
+      final parts = jwt.split('.');
+      if (parts.length != 3) return '(not a JWT)';
+
+      String normalize(String s) => s
+          .padRight(s.length + (4 - s.length % 4) % 4, '=')
+          .replaceAll('-', '+')
+          .replaceAll('_', '/');
+
+      final payload = utf8.decode(base64Url.decode(normalize(parts[1])));
+      return payload;
+    } catch (_) {
+      return '(decode failed)';
+    }
+  }
+
+  /// JWT에서 memberId 추출: memberId 우선, 없으면 sub
+  static int? extractMemberId(String jwt) {
+    try {
+      final parts = jwt.split('.');
+      if (parts.length != 3) return null;
+
+      String normalize(String s) => s
+          .padRight(s.length + (4 - s.length % 4) % 4, '=')
+          .replaceAll('-', '+')
+          .replaceAll('_', '/');
+
+      final payloadJson = utf8.decode(base64Url.decode(normalize(parts[1])));
+      final map = jsonDecode(payloadJson) as Map<String, dynamic>;
+      final v = map['memberId'] ?? map['sub'];
+      if (v == null) return null;
+      return int.tryParse(v.toString());
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -114,7 +114,7 @@ packages:
     source: hosted
     version: "7.0.3"
   dio:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: dio
       sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
@@ -590,7 +590,7 @@ packages:
     source: hosted
     version: "3.9.1"
   provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: provider
       sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,8 +2,7 @@ name: inninglog
 description: "A new Flutter project."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 version: 1.0.0+1
 
@@ -23,7 +22,6 @@ dependencies:
 
   url_launcher: ^6.2.5
 
-
   cupertino_icons: ^1.0.8
   flutter_svg: ^2.0.7
   image_picker: ^1.1.2
@@ -37,26 +35,20 @@ dependencies:
   flutter_dotenv: ^5.2.1
   fluttertoast: ^8.2.4
   device_info_plus: ^10.1.0
-  xml: ^6.5.0              # SVG XML 파싱
-  path_parsing: ^1.0.1     # d → Path 변환
+  xml: ^6.5.0 # SVG XML 파싱
+  path_parsing: ^1.0.1 # d → Path 변환
   path_drawing: ^1.0.1
   webview_flutter: ^4.13.0
-
-
-
-
+  dio: ^5.0.0
+  provider: ^6.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-
   flutter_lints: ^5.0.0
 
-
-
 flutter:
-
   uses-material-design: true
 
   assets:
@@ -68,8 +60,6 @@ flutter:
     - assets/images/onboarding_3.jpg
     - assets/images/onboarding_4.jpg
     - assets/jamsil.svg
-
-
 
   fonts:
     - family: MBC1961GulimOTF
@@ -87,5 +77,3 @@ flutter:
     - family: omyu pretty
       fonts:
         - asset: assets/fonts/omyu pretty.ttf
-
-


### PR DESCRIPTION
## 🎯요약(Summary)

API 호출마다 `SharedPreferences`에서 토큰을 읽고, `http`로 요청/파싱/에러처리를 각 함수에서 반복하는 기존 구조를 다음과 같이 개선했습니다. 

- 인증/토큰 관리 단일화(TokenStorage + AuthSession)
- 네트워크 공통 설정 단일화(ApiClient/Dio + interceptor)
- 도메인별 Repository 확장 가능한 형태로 정리(AppScope/Provider)

## 💻 상세 내용(Describe your changes)

### ✅ 인증/세션 관련
- `TokenStorage` 추가
  - accessToken/refreshToken 저장/조회/삭제 책임 분리
  - (기존 SharedPreferences 직접 접근 로직 대체 기반)
- `AuthSession` 추가
  - 현재 세션(로그인 여부 판단, 토큰 존재 여부 등) 접근 지점을 한 곳으로 통합
  - UI/VM에서 “로그인 상태” 판단 시 TokenStorage를 직접 만지지 않도록 가이드 역할

### ✅ 네트워크 공통화
- `ApiClient(Dio)` 공통 인스턴스 추가
  - baseUrl/timeout/headers 통일
  - interceptor로 `Authorization: Bearer <accessToken>` 자동 주입
- 공통 에러 타입(`AppError`) 기반 처리 구조

### ✅ 의존성 조립/주입
- `AppScope`에서 의존성 조립(토큰 저장소 + AuthSession + ApiClient + 각 Repository)
- `main.dart`에서 `Provider<AppScope>`로 앱 전체에 scope 제공

## 도메인 Repository를 추가하는 방법 (가이드)

### Step 1. Repository 파일 생성
> 서버 공통 응답 래퍼인 `ApiEnvelope<T>`를 통해 `data`를 꺼내 파싱합니다.

```dart
class CommunityPostRepository {
  final Dio _dio;
  CommunityPostRepository(this._dio);

  /// 게시글 목록 예시
  Future<List<CommunityPost>> fetchPosts({
    required String teamCode,
    int page = 0,
    int size = 20,
  }) async {
    final res = await _dio.get(
      'boards/$teamCode/posts',
      queryParameters: {'page': page, 'size': size},
    );

    final envelope = ApiEnvelope.fromJson(
      res.data as Map<String, dynamic>,
      (dataJson) => (dataJson as List<dynamic>)
          .whereType<Map<String, dynamic>>()
          .map(CommunityPost.fromJson)
          .toList(),
    );

    return envelope.data ?? <CommunityPost>[];
  }

}
```
> ✅ 토큰 헤더는 Repository에서 직접 붙이지 않습니다. ApiClient interceptor가 TokenStorage에서 accessToken을 읽어 자동 주입합니다.

### Step 2. AppScope 에 Repository 등록
- `lib/app_scope.dart` 에 추가 

```dart
late final CommunityPostRepository communityPostRepository =
    CommunityPostRepository(apiClient.dio);

```

### Step 3. ViewModel에서 사용
- 화면(UI)은 네트워크 호출을 직접 하지 않고, VM이 repository를 호출하도록 구성합니다.

``` dart
class CommunityPostListViewModel extends ChangeNotifier {
  final CommunityPostRepository _repo;
  CommunityPostListViewModel(this._repo);

  bool isLoading = false;
  List<CommunityPost> posts = [];

  Future<void> load(String teamCode) async {
    isLoading = true;
    notifyListeners();
    posts = await _repo.fetchPostDetail(teamCode: teamCode);
    isLoading = false;
    notifyListeners();
  }
}

```
- 화면(페이지 코드)에서 주입:

```dart
final scope = context.read<AppScope>(); // 또는 AppDependencies
final repo = scope.communityPostRepository;

return ChangeNotifierProvider(
  create: (_) => CommunityPostListViewModel(repo)..load(teamCode),
  child: const CommunityPageView(),
);

```
## 📌 관련 이슈번호(Related Issue)
- closed: #54 

## ✅ TODO
- [ ] 커뮤니티 게시글 등록 기능 구현 
