### PR TITLE
[Feat] 게시물 등록 및 이미지 업로드 API 연동

### DIFF
--- a/lib/feature/community/model/dto/create_post_dtos.dart
+++ b/lib/feature/community/model/dto/create_post_dtos.dart
@@ -1,3 +1,4 @@
+/// API 요청/응답 DTO 모음 (커뮤니티 게시글 작성/업로드 관련)
 class ImageCreateReqDto {
   final int sequence;
   final String key;
@@ -12,6 +13,48 @@ class ImageCreateReqDto {
   }
 
   Map<String, dynamic> toJson() => {'sequence': sequence, 'key': key};
+}
+
+/// 게시글 업로드 시 클라이언트가 준비하는 이미지 정보
+class ImageUploadReqDto {
+  final int sequence;
+  final String fileName;
+  final String contentType;
+
+  const ImageUploadReqDto({
+    required this.sequence,
+    required this.fileName,
+    required this.contentType,
+  });
+
+  Map<String, dynamic> toRequestJson() => {
+    'sequence': sequence,
+    'fileName': fileName,
+    'contentType': contentType,
+  };
+}
+
+/// Presigned URL 발급 응답 객체
+class ImageUploadResDto extends ImageCreateReqDto {
+  final String presignedUrl;
+
+  const ImageUploadResDto({
+    required super.sequence,
+    required super.key,
+    required this.presignedUrl,
+  });
+
+  factory ImageUploadResDto.fromJson(Map<String, dynamic> json) {
+    final seq = json['sequence'];
+    final url = json['presignedUrl'] ?? json['url'] ?? json['uploadUrl'] ?? '';
+    final key = json['key'] ?? json['s3Key'] ?? json['objectKey'] ?? '';
+
+    return ImageUploadResDto(
+      sequence: seq is int ? seq : int.tryParse('$seq') ?? 0,
+      key: key.toString(),
+      presignedUrl: url.toString(),
+    );
+  }
 }
 
 class CreatePostRequest {
@@ -42,17 +85,4 @@ class CreatePostRequest {
     'content': content,
     'imageCreateReqDto': imageCreateReqDto.map((e) => e.toJson()).toList(),
   };
-
-  /// 이미지 없이 쓰기 편한 헬퍼(선택)
-  CreatePostRequest copyWith({
-    String? title,
-    String? content,
-    List<ImageCreateReqDto>? imageCreateReqDto,
-  }) {
-    return CreatePostRequest(
-      title: title ?? this.title,
-      content: content ?? this.content,
-      imageCreateReqDto: imageCreateReqDto ?? this.imageCreateReqDto,
-    );
-  }
 }

--- a/lib/feature/community/repositories/post_repository.dart
+++ b/lib/feature/community/repositories/post_repository.dart
@@ -1,7 +1,5 @@
-import 'dart:typed_data';
-
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import '../../../shared/network/api_envelope.dart';
 import '../model/dto/create_post_dtos.dart';
@@ -73,14 +71,25 @@ class CommunityPostRepository {
 
     required String contentType,
   }) async {
-    final res = await http.put(
-      Uri.parse(target.presignedUrl),
-      headers: {'Content-Type': contentType},
-    );
+    try {
+      final res = await http.put(
+        Uri.parse(target.presignedUrl),
+        headers: {'Content-Type': contentType},
+      );
 
-    final status = res.statusCode;
-    if (status >= 400) {
-      throw Exception('Failed to upload image (status: $status)');
+      if (res.statusCode >= 400) {
+        // 최대 N바이트만 잘라서 남기면 길어지지 않음
+        final body = res.body;
+        throw Exception(
+          'Failed to upload image '
+          '(status: ${res.statusCode}, reason: ${res.reasonPhrase}, '
+          'headers: ${res.headers}, body: ${body.length > 500 ? body.substring(0, 500) : body})',
+        );
+      }
+    } catch (e, st) {
+      // 전역 로거/크래시리틱스가 있다면 여기서 함께 기록
+      debugPrint('uploadToS3 error: $e\n$st');
+      rethrow;
     }
   }
 }

--- a/lib/feature/community/repositories/post_repository.dart
+++ b/lib/feature/community/repositories/post_repository.dart
@@ -1,6 +1,10 @@
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 import '../../../shared/network/api_envelope.dart';
-import '../model/create_post_request.dart';
+import '../model/dto/create_post_dtos.dart';
 
 class CommunityPostRepository {
   final Dio _dio;
@@ -22,5 +26,61 @@ class CommunityPostRepository {
       throw const FormatException('Unexpected response shape');
     }
     return ApiEnvelope.fromJson(json);
+  }
+
+  /// 게시글 이미지 Presigned URL 목록 발급
+  Future<List<ImageUploadResDto>> requestImagePresignedUrls({
+    required List<ImageUploadReqDto> images,
+  }) async {
+    if (images.isEmpty) return const [];
+
+    final res = await _dio.post(
+      '/images/upload/post',
+      data: {
+        'imageUploadReqDto': images.map((e) => e.toRequestJson()).toList(),
+      },
+    );
+
+    final json = res.data;
+    if (json is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected presigned response shape');
+    }
+
+    final envelope = ApiEnvelope.fromJson(json);
+    final data = envelope.data;
+
+    List<dynamic>? items;
+    if (data is List) {
+      items = data;
+    } else if (data is Map<String, dynamic>) {
+      final nested = data['imageUploadResDtos'];
+      if (nested is List) items = nested;
+    }
+
+    if (items == null) {
+      throw const FormatException('Presigned URL list not found in response');
+    }
+
+    return items
+        .whereType<Map<String, dynamic>>()
+        .map(ImageUploadResDto.fromJson)
+        .toList();
+  }
+
+  /// Presigned URL로 S3 업로드
+  Future<void> uploadToS3({
+    required ImageUploadResDto target,
+
+    required String contentType,
+  }) async {
+    final res = await http.put(
+      Uri.parse(target.presignedUrl),
+      headers: {'Content-Type': contentType},
+    );
+
+    final status = res.statusCode;
+    if (status >= 400) {
+      throw Exception('Failed to upload image (status: $status)');
+    }
   }
 }

--- a/lib/feature/community/screens/writing_post_page.dart
+++ b/lib/feature/community/screens/writing_post_page.dart
@@ -35,7 +35,7 @@ class _WritingPostView extends StatelessWidget {
   const _WritingPostView({required this.teamCode});
 
   void _submit(BuildContext context, WritingPostViewModel vm) {
-    vm.submit(teamCode: teamCode); // TODO: 등록 API 연동 시 vm.submit()로 변경
+    vm.submit(teamCode: teamCode);
     Navigator.of(context).pop();
   }
 

--- a/lib/feature/community/viewmodel/writing_post_view_model.dart
+++ b/lib/feature/community/viewmodel/writing_post_view_model.dart
@@ -1,6 +1,7 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
-import 'package:inninglog/app_scope.dart';
-import 'package:inninglog/feature/community/model/create_post_request.dart';
+import 'package:inninglog/feature/community/model/dto/create_post_dtos.dart';
 import 'package:inninglog/feature/community/repositories/post_repository.dart';
 import 'package:inninglog/shared/service/image_pick_service.dart';
 
@@ -13,8 +14,12 @@ class WritingPostViewModel extends ChangeNotifier {
   final FocusNode titleFocusNode = FocusNode();
   final FocusNode bodyFocusNode = FocusNode();
 
-  final List<ImageProvider> _images = [];
-  List<ImageProvider> get images => List.unmodifiable(_images);
+  final List<_PendingImage> _images = [];
+  List<ImageProvider> get images =>
+      List.unmodifiable(_images.map((e) => e.provider));
+
+  bool _isDisposed = false;
+  bool _isSubmitting = false;
 
   final CommunityPostRepository repo;
 
@@ -28,7 +33,8 @@ class WritingPostViewModel extends ChangeNotifier {
   bool get isFormFilled => _isFormFilled;
 
   bool get canPickMore => _images.length < maxImages;
-  bool get canSubmit => _isFormFilled;
+  bool get canSubmit => _isFormFilled && !_isSubmitting;
+  bool get isSubmitting => _isSubmitting;
 
   WritingPostViewModel({
     required this.imagePickService,
@@ -43,59 +49,114 @@ class WritingPostViewModel extends ChangeNotifier {
   Future<void> pickFromGallery() async {
     if (!canPickMore || _isPicking) return;
     _isPicking = true;
-    notifyListeners();
+    _safeNotify();
 
     try {
       final remain = maxImages - _images.length;
       final bytesList = await imagePickService.pickMultiBytes(limit: remain);
 
-      _images.addAll(bytesList.map((b) => MemoryImage(b)));
-      notifyListeners();
+      final now = DateTime.now().millisecondsSinceEpoch;
+      for (var i = 0; i < bytesList.length; i++) {
+        final bytes = bytesList[i];
+        final contentType = _detectContentType(bytes);
+        final ext = contentType == 'image/png' ? 'png' : 'jpg';
+        final fileName = 'community_${now}_${_images.length + i}.$ext';
+
+        _images.add(
+          _PendingImage(
+            bytes: bytes,
+            fileName: fileName,
+            contentType: contentType,
+          ),
+        );
+      }
+      _safeNotify();
     } finally {
       _isPicking = false;
-      notifyListeners();
+      _safeNotify();
     }
   }
 
-  /// 임시 제출/디버그용 로그
-  void submitDraft() {
-    final title = titleController.text.trim();
-    final body = bodyController.text.trim();
-    debugPrint('[WritingPost] submitDraft');
-    debugPrint('  title: "$title"');
-    debugPrint('  body: "$body"');
-    debugPrint('  imageCount: ${_images.length}');
-  }
-
   Future<void> submit({required String teamCode}) async {
-    // submitting = true;
-    // error = null;
-    notifyListeners();
+    if (_isDisposed || _isSubmitting) return;
+
+    _isSubmitting = true;
+    _safeNotify();
     final title = titleController.text.trim();
     final content = bodyController.text.trim();
 
     try {
+      debugPrint(
+        '[WritingPost] submit team=$teamCode titleLen=${title.length} images=${_images.length}',
+      );
+      final uploadImages =
+          _images
+              .asMap()
+              .entries
+              .map(
+                (entry) => ImageUploadReqDto(
+                  sequence: entry.key + 1,
+                  fileName: entry.value.fileName,
+                  contentType: entry.value.contentType,
+                ),
+              )
+              .toList();
+
+      List<ImageCreateReqDto> imageKeys = [];
+
+      if (uploadImages.isNotEmpty) {
+        final presignedList = await repo.requestImagePresignedUrls(
+          images: uploadImages,
+        );
+        final presignedMap = {
+          for (final item in presignedList) item.sequence: item,
+        };
+
+        for (final image in uploadImages) {
+          final presigned = presignedMap[image.sequence];
+          if (presigned == null) {
+            throw StateError(
+              'Presigned URL missing for sequence ${image.sequence}',
+            );
+          }
+
+          debugPrint(
+            '[WritingPost] upload seq=${image.sequence} url=${presigned.presignedUrl}',
+          );
+          await repo.uploadToS3(
+            target: presigned,
+            contentType: image.contentType,
+          );
+          imageKeys.add(
+            ImageCreateReqDto(sequence: presigned.sequence, key: presigned.key),
+          );
+        }
+
+        imageKeys.sort((a, b) => a.sequence.compareTo(b.sequence));
+      }
+
+      debugPrint('[WritingPost] createPost keys=${imageKeys.length}');
       await repo.createPost(
         teamCode: teamCode,
         request: CreatePostRequest(
           title: title,
           content: content,
-          imageCreateReqDto: [],
+          imageCreateReqDto: imageKeys,
         ),
       );
     } catch (e) {
       debugPrint(e.toString());
       // error = e.toString();
     } finally {
-      // submitting = false;
-      notifyListeners();
+      _isSubmitting = false;
+      _safeNotify();
     }
   }
 
   void removeImageAt(int index) {
     if (index < 0 || index >= _images.length) return;
     _images.removeAt(index);
-    notifyListeners();
+    _safeNotify();
   }
 
   void _handleTitleFocusChanged() {
@@ -126,6 +187,40 @@ class WritingPostViewModel extends ChangeNotifier {
       ..removeListener(_handleTitleFocusChanged)
       ..dispose();
     bodyFocusNode.dispose();
+    _isDisposed = true;
     super.dispose();
   }
+
+  void _safeNotify() {
+    if (_isDisposed) return;
+    notifyListeners();
+  }
+}
+
+class _PendingImage {
+  final Uint8List bytes;
+  final String fileName;
+  final String contentType;
+
+  const _PendingImage({
+    required this.bytes,
+    required this.fileName,
+    required this.contentType,
+  });
+
+  ImageProvider get provider => MemoryImage(bytes);
+}
+
+String _detectContentType(Uint8List bytes) {
+  if (bytes.length >= 4 &&
+      bytes[0] == 0x89 &&
+      bytes[1] == 0x50 &&
+      bytes[2] == 0x4e &&
+      bytes[3] == 0x47) {
+    return 'image/png';
+  }
+  if (bytes.length >= 2 && bytes[0] == 0xff && bytes[1] == 0xd8) {
+    return 'image/jpeg';
+  }
+  return 'image/jpeg';
 }


### PR DESCRIPTION
## 🎯요약(Summary)
- 게시물 작성 페이지에 커뮤니티 게시물 등록 및 이미지 업로드 API를 연동했습니다. 

## 💻 상세 내용(Describe your changes)
- API request/response 모델 관리를 위해 dto 디렉토리를 분리
- 이미지 업로드 플로우를 구현
  - Presigned URL 발급 API 호출
  - 발급받은 URL로 S3에 PUT 업로드
  - 업로드된 이미지 URL(또는 key)을 포함해 게시물 등록 API 호출
  
## 📸 발생 이슈 
- S3에 PUT 업로드 과정에서 권한 문제가 발생해 해결 후 테스트 필요

## 📌 관련 이슈번호(Related Issue)
- closed: #53 

## ✅ TODO
- [ ] S3 PUT 업로드 테스트
