### PR TITLE
[Feat] 커뮤니티 Post 상세 화면 상단 UI 구현 및 API 연동

### DIFF
--- a/lib/feature/community/repositories/post_repository.dart
+++ b/lib/feature/community/repositories/post_repository.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:inninglog/feature/community/model/community_post.dart';
 import 'package:inninglog/feature/community/model/dto/post_dtos.dart';
 import '../../../shared/network/api_envelope.dart';
 import '../model/dto/create_post_dtos.dart';
@@ -109,5 +110,50 @@ class CommunityPostRepository {
       throw const FormatException('Unexpected post list response');
     }
     return PostListResponse.fromJson(json);
+  }
+
+  /// 게시글 상세 조회
+  /// 응답 스펙: { code: string, message: string, data: { ... } }
+  Future<CommunityPostItem> getPostDetail({required int postId}) async {
+    final res = await _dio.get('/community/posts/$postId');
+
+    final json = res.data;
+    if (json is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected post detail response');
+    }
+
+    return CommunityPostItem.fromJson(json);
+  }
+
+  /// 게시글 좋아요
+  Future<void> likePost({required int postId}) async {
+    final res = await _dio.post('/community/posts/$postId/likes');
+    if (res.data is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected like response');
+    }
+  }
+
+  /// 게시글 좋아요 취소
+  Future<void> unlikePost({required int postId}) async {
+    final res = await _dio.delete('/community/posts/$postId/likes');
+    if (res.data is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected unlike response');
+    }
+  }
+
+  /// 게시글 스크랩
+  Future<void> scrapPost({required int postId}) async {
+    final res = await _dio.post('/community/posts/$postId/scraps');
+    if (res.data is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected scrap response');
+    }
+  }
+
+  /// 게시글 스크랩 취소
+  Future<void> unscrapPost({required int postId}) async {
+    final res = await _dio.delete('/community/posts/$postId/scraps');
+    if (res.data is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected unscrap response');
+    }
   }
 }

--- a/lib/feature/community/screens/post_detail_market.dart
+++ b/lib/feature/community/screens/post_detail_market.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/feature/community/widgets/post_detail/post_action_button.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
 
 class PostDetailMarketArgs {
@@ -641,7 +642,7 @@ class _ActionBar extends StatelessWidget {
               // 댓글
               Expanded(
                 child: Center(
-                  child: _InlineAction(
+                  child: PostActionButton(
                     asset: 'assets/icons/board_comment.svg',
                     color: AppColors.gray500,
                     label: _labelWithCount('댓글', commentCount),
@@ -654,7 +655,7 @@ class _ActionBar extends StatelessWidget {
               // 스크랩
               Expanded(
                 child: Center(
-                  child: _InlineAction(
+                  child: PostActionButton(
                     asset: 'assets/icons/board_scrap.svg',
                     color:
                     scrapActive ? AppColors.primary700 : AppColors.gray500,
@@ -679,52 +680,6 @@ class _ActionBar extends StatelessWidget {
 }
 
 
-class _InlineAction extends StatelessWidget {
-  final String asset;
-  final String label;
-  final Color color;
-  final VoidCallback? onTap;
-  final double iconSize;
-
-  const _InlineAction({
-    required this.asset,
-    required this.label,
-    required this.color,
-    required this.onTap,
-    this.iconSize = 18,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final content = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SvgPicture.asset(
-          asset,
-          width: 16,
-          height: 16,
-          colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
-        ),
-        const SizedBox(width: 4),
-        Text(
-          label,
-          style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: color),
-        ),
-      ],
-    );
-
-    if (onTap == null) return content;
-
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(6),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-        child: content,
-      ),
-    );
-  }
-}
 
 /// 댓글 없을 때
 class _EmptyComment extends StatelessWidget {
@@ -1090,4 +1045,3 @@ class _TagChip extends StatelessWidget {
     );
   }
 }
-

--- a/lib/feature/community/screens/post_detail_page.dart
+++ b/lib/feature/community/screens/post_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/feature/community/widgets/post_detail/post_detail_app_bar.dart';
 import 'package:inninglog/shared/constant/team_codes.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
 
@@ -60,58 +61,20 @@ class _PostDetailPageState extends State<PostDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final teamLabel = teamLabelFromCode(widget.teamCode);
+    final teamLabel =
+        widget.teamCode == 'ALL' ? '전체게시판' : teamLabelFromCode(widget.teamCode);
+
     final commentCount = comments.length;
 
     return Scaffold(
       backgroundColor: AppColors.primary50,
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(64),
-        child: AppBar(
-          backgroundColor: Colors.white,
-          elevation: 0,
-          leadingWidth: 54,
-          leading: IconButton(
-            icon: SvgPicture.asset(
-              'assets/icons/back_but.svg',
-              width: 10,
-              height: 20,
-            ),
-            onPressed: () => Navigator.pop(context),
-          ),
-          centerTitle: true,
-          title: Column(
-            children: [
-              const Text(
-                '자유 게시판',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontFamily: 'Pretendard',
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.gray900,
-                ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                teamLabel,
-                style: const TextStyle(
-                  fontSize: 14,
-                  fontFamily: 'Pretendard',
-                  fontWeight: FontWeight.w500,
-                  color: AppColors.gray700,
-                ),
-              ),
-            ],
-          ),
-          actions: [
-            IconButton(
-              icon: SvgPicture.asset('assets/icons/board_dots.svg', width: 18),
-              onPressed: () {},
-            ),
-          ],
-        ),
+      appBar: PostDetailAppBar(
+        teamLabel: teamLabel,
+        onBack: () => Navigator.pop(context),
+        onTapMore: () {
+          // TODO: 신고/삭제/공유 bottom sheet 등
+        },
       ),
-
       // 하단 입력바 (디자인 유지)
       bottomNavigationBar:
           (_activeReplyIndex == null)

--- a/lib/feature/community/screens/post_detail_page.dart
+++ b/lib/feature/community/screens/post_detail_page.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/app_scope.dart';
+import 'package:inninglog/feature/community/viewmodel/post_detail_view_model.dart';
+import 'package:inninglog/feature/community/widgets/post_detail/post_action_bar.dart';
 import 'package:inninglog/feature/community/widgets/post_detail/post_detail_app_bar.dart';
+import 'package:inninglog/feature/community/widgets/post_detail/post_header_section.dart';
 import 'package:inninglog/shared/constant/team_codes.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:provider/provider.dart';
 
 class PostDetailPage extends StatefulWidget {
   final String teamCode;
@@ -19,19 +24,14 @@ class PostDetailPage extends StatefulWidget {
 }
 
 class _PostDetailPageState extends State<PostDetailPage> {
+  late final PostDetailViewModel _vm;
+
   // ▼ 대댓글 상태 저장 (기존 코드 보존)
   final Map<int, List<_Reply>> _replies = {}; // 댓글 index -> 대댓글 목록
   final Set<int> _replying = {}; // 대댓글 입력창 열려있는 댓글 index
 
   int? _activeReplyIndex;
   final _replyCtrl = TextEditingController();
-
-  // 상태
-  bool liked = false;
-  int likeCount = 20;
-
-  bool scrapped = false;
-  int scrapCount = 0;
 
   final _commentCtrl = TextEditingController();
 
@@ -53,7 +53,15 @@ class _PostDetailPageState extends State<PostDetailPage> {
   ];
 
   @override
+  void initState() {
+    super.initState();
+    final repo = context.read<AppScope>().communityPostRepository;
+    _vm = PostDetailViewModel(repo: repo, postId: widget.postId)..fetch();
+  }
+
+  @override
   void dispose() {
+    _vm.dispose();
     _commentCtrl.dispose();
     _replyCtrl.dispose();
     super.dispose();
@@ -61,172 +69,111 @@ class _PostDetailPageState extends State<PostDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final teamLabel =
-        widget.teamCode == 'ALL' ? '전체게시판' : teamLabelFromCode(widget.teamCode);
+    return ChangeNotifierProvider<PostDetailViewModel>.value(
+      value: _vm,
+      child: Consumer<PostDetailViewModel>(
+        builder: (context, vm, _) {
+          final post = vm.post;
+          final teamCode = post?.teamCode ?? widget.teamCode;
+          final teamLabel =
+              teamCode == 'ALL' ? 'KBO 전체게시판' : teamLabelFromCode(teamCode);
+          final commentCount =
+              vm.commentCount > 0 ? vm.commentCount : comments.length;
 
-    final commentCount = comments.length;
+          return Scaffold(
+            backgroundColor: AppColors.primary50,
+            appBar: PostDetailAppBar(
+              teamLabel: teamLabel,
+              onBack: () => Navigator.pop(context),
+              onTapMore: () {
+                // TODO: 신고/삭제/공유 bottom sheet 등
+              },
+            ),
+            // 하단 입력바 (디자인 유지)
+            bottomNavigationBar:
+                (_activeReplyIndex == null)
+                    // 기본 댓글 입력창
+                    ? _CommentInputBar(
+                      controller: _commentCtrl,
+                      onPressed: () {
+                        final text = _commentCtrl.text.trim();
+                        if (text.isEmpty) return;
+                        setState(() {
+                          comments.add(
+                            _Comment(
+                              nickname: '닉네임',
+                              body: text,
+                              time: '방금',
+                              liked: false,
+                              likes: 0,
+                            ),
+                          );
+                          _commentCtrl.clear();
+                        });
+                      },
+                    )
+                    // ✅ 대댓글 모드일 때
+                    : _ReplyBottomBar(
+                      nickname: comments[_activeReplyIndex!].nickname,
+                      controller: _replyCtrl,
+                      onCancel: () => setState(() => _activeReplyIndex = null),
+                      onSubmit: () {
+                        final text = _replyCtrl.text.trim();
+                        if (text.isEmpty) return;
+                        final i = _activeReplyIndex!;
+                        setState(() {
+                          final cur = List<_Reply>.from(
+                            _replies[i] ?? const [],
+                          );
+                          cur.add(
+                            _Reply(
+                              nickname: '나나ㅏ나',
+                              body: text.trim(),
+                              time: '방금',
+                              likes: 0,
+                              liked: false,
+                            ),
+                          );
 
-    return Scaffold(
-      backgroundColor: AppColors.primary50,
-      appBar: PostDetailAppBar(
-        teamLabel: teamLabel,
-        onBack: () => Navigator.pop(context),
-        onTapMore: () {
-          // TODO: 신고/삭제/공유 bottom sheet 등
-        },
-      ),
-      // 하단 입력바 (디자인 유지)
-      bottomNavigationBar:
-          (_activeReplyIndex == null)
-              // 기본 댓글 입력창
-              ? _CommentInputBar(
-                controller: _commentCtrl,
-                onPressed: () {
-                  final text = _commentCtrl.text.trim();
-                  if (text.isEmpty) return;
-                  setState(() {
-                    comments.add(
-                      _Comment(
-                        nickname: '닉네임',
-                        body: text,
-                        time: '방금',
-                        liked: false,
-                        likes: 0,
-                      ),
-                    );
-                    _commentCtrl.clear();
-                  });
-                },
-              )
-              // ✅ 대댓글 모드일 때
-              : _ReplyBottomBar(
-                nickname: comments[_activeReplyIndex!].nickname,
-                controller: _replyCtrl,
-                onCancel: () => setState(() => _activeReplyIndex = null),
-                onSubmit: () {
-                  final text = _replyCtrl.text.trim();
-                  if (text.isEmpty) return;
-                  final i = _activeReplyIndex!;
-                  setState(() {
-                    final cur = List<_Reply>.from(_replies[i] ?? const []);
-                    cur.add(
-                      _Reply(
-                        nickname: '나나ㅏ나',
-                        body: text.trim(),
-                        time: '방금',
-                        likes: 0,
-                        liked: false,
-                      ),
-                    );
+                          _replies[i] = cur;
+                          _activeReplyIndex = null;
+                          _replyCtrl.clear();
+                        });
+                      },
+                    ),
 
-                    _replies[i] = cur;
-                    _activeReplyIndex = null;
-                    _replyCtrl.clear();
-                  });
-                },
-              ),
-
-      body: ListView(
-        children: [
-          _postHeader(),
-          // ✅ 액션 바: 한 군데만 존재
-          _ActionBar(
-            likeActive: liked,
-            likeCount: likeCount,
-            onTapLike: () {
-              setState(() {
-                liked = !liked;
-                liked ? likeCount++ : likeCount--;
-              });
-            },
-            scrapActive: scrapped,
-            scrapCount: scrapCount,
-            onTapScrap: () {
-              setState(() {
-                scrapped = !scrapped;
-                scrapped ? scrapCount++ : scrapCount--;
-              });
-            },
-            commentCount: commentCount,
-          ),
-          const Divider(height: 8, color: AppColors.gray200),
-          // 댓글은 고정 노출(토글 X)
-          if (comments.isEmpty)
-            _EmptyComment()
-          else
-            ...comments.map(_commentItem),
-          const SizedBox(height: 6),
-        ],
-      ),
-    );
-  }
-
-  //게시판
-  Widget _postHeader() {
-    return Container(
-      color: AppColors.primary50,
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // 작성자
-          Row(
-            //작성자 프사 -> 어차피 바꿀거라
-            children: [
-              Container(
-                width: 40,
-                height: 40,
-                decoration: const BoxDecoration(
-                  color: Color(0xFFE5E7EB),
-                  shape: BoxShape.circle,
+            body: ListView(
+              children: [
+                PostSection(
+                  content: post?.content ?? '',
+                  createAt: post?.createdAt ?? '',
+                  nickName: post?.nickName ?? '',
+                  title: post?.title ?? '',
+                  imageUrls:
+                      post?.images.map((e) => e.url).toList() ?? const [],
+                  profileUrl: post?.profileUrl,
                 ),
-              ),
-              const SizedBox(width: 8),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: const [
-                  Text(
-                    '디디는디디',
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w800,
-                      color: AppColors.gray800,
-                    ),
-                  ),
-                  SizedBox(height: 0),
-                  Text(
-                    '05/25(일) 11:02',
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: AppColors.gray700,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
+                PostActionBar(
+                  likeActive: vm.likedByMe,
+                  likeCount: vm.likeCount,
+                  onTapLike: vm.toggleLike,
+                  scrapActive: vm.scrapedByMe,
+                  scrapCount: vm.scrapCount,
+                  onTapScrap: vm.toggleScrap,
+                  commentCount: commentCount,
+                ),
+                const Divider(height: 8, color: AppColors.gray200),
 
-          const Text(
-            '강백호 ㅇㄷ 갈거가틈',
-            style: TextStyle(
-              fontSize: 19,
-              fontWeight: FontWeight.w700,
-              color: AppColors.gray850,
+                // 댓글은 고정 노출(토글 X)
+                if (comments.isEmpty)
+                  _EmptyComment()
+                else
+                  ...comments.map(_commentItem),
+                const SizedBox(height: 6),
+              ],
             ),
-          ),
-          const SizedBox(height: 16),
-
-          const Text(
-            'ㅈㄱㄴ',
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.w400,
-              color: AppColors.gray900,
-            ),
-          ),
-        ],
+          );
+        },
       ),
     );
   }
@@ -479,136 +426,6 @@ class _PostDetailPageState extends State<PostDetailPage> {
 }
 
 /// ───────────────────────── 위젯들 ─────────────────────────
-
-class _ActionBar extends StatelessWidget {
-  final bool likeActive;
-  final int likeCount;
-  final VoidCallback onTapLike;
-
-  final bool scrapActive;
-  final int scrapCount;
-  final VoidCallback onTapScrap;
-
-  final int commentCount;
-
-  const _ActionBar({
-    required this.likeActive,
-    required this.likeCount,
-    required this.onTapLike,
-    required this.scrapActive,
-    required this.scrapCount,
-    required this.onTapScrap,
-    required this.commentCount,
-  });
-
-  String _labelWithCount(String base, int count) {
-    // 0이면 숫자 미표시, 그 외엔 "base n"
-    return count <= 0 ? base : '$base $count';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    const gray = Color(0xFFD3D3D3);
-
-    return Container(
-      color: AppColors.primary50,
-      padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
-      child: Row(
-        children: [
-          // 공감
-          Expanded(
-            child: Center(
-              child: _InlineAction(
-                asset: 'assets/icons/board_heart.svg',
-                color: likeActive ? AppColors.primary700 : AppColors.gray500,
-                label: _labelWithCount('공감', likeCount),
-                onTap: onTapLike,
-                iconSize: 18, // ← 아이콘 크기
-              ),
-            ),
-          ),
-
-          // 댓글 (항상 회색, 숫자만 변화)
-          Expanded(
-            child: Center(
-              child: _InlineAction(
-                asset: 'assets/icons/board_comment.svg',
-                color: AppColors.gray500,
-                label: _labelWithCount('댓글', commentCount),
-                onTap: null, // 눌러도 아무 동작 없음
-                iconSize: 18,
-              ),
-            ),
-          ),
-
-          // 스크랩
-          Expanded(
-            child: Center(
-              child: _InlineAction(
-                asset: 'assets/icons/board_scrap.svg',
-                color: scrapActive ? AppColors.primary700 : AppColors.gray500,
-                label: _labelWithCount('스크랩', scrapCount),
-                onTap: onTapScrap,
-                iconSize: 18,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _InlineAction extends StatelessWidget {
-  final String asset;
-  final String label;
-  final Color color;
-  final VoidCallback? onTap;
-  final double iconSize;
-
-  const _InlineAction({
-    required this.asset,
-    required this.label,
-    required this.color,
-    required this.onTap,
-    this.iconSize = 18,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final content = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SvgPicture.asset(
-          asset,
-          width: 16,
-          height: 16,
-          colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
-        ),
-        const SizedBox(width: 4),
-        Text(
-          label,
-          style: TextStyle(
-            fontSize: 12,
-            fontWeight: FontWeight.w600,
-            color: color,
-          ),
-        ),
-      ],
-    );
-
-    if (onTap == null) return content;
-
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(6),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-        child: content,
-      ),
-    );
-  }
-}
 
 /// 댓글 없을 때
 class _EmptyComment extends StatelessWidget {

--- a/lib/feature/community/screens/post_detail_page.dart
+++ b/lib/feature/community/screens/post_detail_page.dart
@@ -1,36 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/shared/constant/team_codes.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
 
-class PostDetailArgs {
+class PostDetailPage extends StatefulWidget {
   final String teamCode;
-  final String teamLabel;
   final int postId;
-  const PostDetailArgs({
+
+  const PostDetailPage({
+    super.key,
     required this.teamCode,
-    required this.teamLabel,
     required this.postId,
   });
-}
-
-class PostDetailPage extends StatefulWidget {
-  final PostDetailArgs args;
-  const PostDetailPage({super.key, required this.args});
-
 
   @override
   State<PostDetailPage> createState() => _PostDetailPageState();
 }
 
 class _PostDetailPageState extends State<PostDetailPage> {
-
   // ▼ 대댓글 상태 저장 (기존 코드 보존)
   final Map<int, List<_Reply>> _replies = {}; // 댓글 index -> 대댓글 목록
-  final Set<int> _replying = {};              // 대댓글 입력창 열려있는 댓글 index
+  final Set<int> _replying = {}; // 대댓글 입력창 열려있는 댓글 index
 
   int? _activeReplyIndex;
   final _replyCtrl = TextEditingController();
-
 
   // 상태
   bool liked = false;
@@ -63,12 +56,11 @@ class _PostDetailPageState extends State<PostDetailPage> {
     _commentCtrl.dispose();
     _replyCtrl.dispose();
     super.dispose();
-
   }
 
   @override
   Widget build(BuildContext context) {
-    final teamLabel = widget.args.teamLabel;
+    final teamLabel = teamLabelFromCode(widget.teamCode);
     final commentCount = comments.length;
 
     return Scaffold(
@@ -80,7 +72,11 @@ class _PostDetailPageState extends State<PostDetailPage> {
           elevation: 0,
           leadingWidth: 54,
           leading: IconButton(
-            icon: SvgPicture.asset('assets/icons/back_but.svg', width: 10,height: 20,),
+            icon: SvgPicture.asset(
+              'assets/icons/back_but.svg',
+              width: 10,
+              height: 20,
+            ),
             onPressed: () => Navigator.pop(context),
           ),
           centerTitle: true,
@@ -117,53 +113,55 @@ class _PostDetailPageState extends State<PostDetailPage> {
       ),
 
       // 하단 입력바 (디자인 유지)
-      bottomNavigationBar: (_activeReplyIndex == null)
-      // 기본 댓글 입력창
-          ? _CommentInputBar(
-        controller: _commentCtrl,
-        onPressed: () {
-          final text = _commentCtrl.text.trim();
-          if (text.isEmpty) return;
-          setState(() {
-            comments.add(
-              _Comment(
-                nickname: '닉네임',
-                body: text,
-                time: '방금',
-                liked: false,
-                likes: 0,
+      bottomNavigationBar:
+          (_activeReplyIndex == null)
+              // 기본 댓글 입력창
+              ? _CommentInputBar(
+                controller: _commentCtrl,
+                onPressed: () {
+                  final text = _commentCtrl.text.trim();
+                  if (text.isEmpty) return;
+                  setState(() {
+                    comments.add(
+                      _Comment(
+                        nickname: '닉네임',
+                        body: text,
+                        time: '방금',
+                        liked: false,
+                        likes: 0,
+                      ),
+                    );
+                    _commentCtrl.clear();
+                  });
+                },
+              )
+              // ✅ 대댓글 모드일 때
+              : _ReplyBottomBar(
+                nickname: comments[_activeReplyIndex!].nickname,
+                controller: _replyCtrl,
+                onCancel: () => setState(() => _activeReplyIndex = null),
+                onSubmit: () {
+                  final text = _replyCtrl.text.trim();
+                  if (text.isEmpty) return;
+                  final i = _activeReplyIndex!;
+                  setState(() {
+                    final cur = List<_Reply>.from(_replies[i] ?? const []);
+                    cur.add(
+                      _Reply(
+                        nickname: '나나ㅏ나',
+                        body: text.trim(),
+                        time: '방금',
+                        likes: 0,
+                        liked: false,
+                      ),
+                    );
+
+                    _replies[i] = cur;
+                    _activeReplyIndex = null;
+                    _replyCtrl.clear();
+                  });
+                },
               ),
-            );
-            _commentCtrl.clear();
-          });
-        },
-      )
-      // ✅ 대댓글 모드일 때
-          : _ReplyBottomBar(
-        nickname: comments[_activeReplyIndex!].nickname,
-        controller: _replyCtrl,
-        onCancel: () => setState(() => _activeReplyIndex = null),
-        onSubmit: () {
-          final text = _replyCtrl.text.trim();
-          if (text.isEmpty) return;
-          final i = _activeReplyIndex!;
-          setState(() {
-            final cur = List<_Reply>.from(_replies[i] ?? const []);
-            cur.add(_Reply(
-              nickname: '나나ㅏ나',
-              body: text.trim(),
-              time: '방금',
-              likes: 0,
-              liked: false,
-            ));
-
-            _replies[i] = cur;
-            _activeReplyIndex = null;
-            _replyCtrl.clear();
-          });
-        },
-      ),
-
 
       body: ListView(
         children: [
@@ -190,7 +188,10 @@ class _PostDetailPageState extends State<PostDetailPage> {
           ),
           const Divider(height: 8, color: AppColors.gray200),
           // 댓글은 고정 노출(토글 X)
-          if (comments.isEmpty) _EmptyComment() else ...comments.map(_commentItem),
+          if (comments.isEmpty)
+            _EmptyComment()
+          else
+            ...comments.map(_commentItem),
           const SizedBox(height: 6),
         ],
       ),
@@ -267,7 +268,6 @@ class _PostDetailPageState extends State<PostDetailPage> {
     );
   }
 
-
   Widget _commentItem(_Comment c) {
     // ▼ 리스트 밖에서 사전 계산 (컴파일 에러 원인 제거)
     final idx = comments.indexOf(c);
@@ -321,10 +321,12 @@ class _PostDetailPageState extends State<PostDetailPage> {
                         'assets/icons/board_comment.svg',
                         width: 14,
                         height: 12,
-                        colorFilter: const ColorFilter.mode(AppColors.gray400, BlendMode.srcIn),
+                        colorFilter: const ColorFilter.mode(
+                          AppColors.gray400,
+                          BlendMode.srcIn,
+                        ),
                       ),
                     ),
-
 
                     _VBar(),
 
@@ -352,11 +354,15 @@ class _PostDetailPageState extends State<PostDetailPage> {
                     // 더보기 (세로 점 3개)
                     _IconButtonBox(
                       onTap: () {}, // 신고/삭제 등 메뉴 오픈
-                      child: const Icon(Icons.more_vert, size: 14, color: AppColors.gray400),
+                      child: const Icon(
+                        Icons.more_vert,
+                        size: 14,
+                        color: AppColors.gray400,
+                      ),
                     ),
                   ],
                 ),
-              )
+              ),
             ],
           ),
 
@@ -390,112 +396,124 @@ class _PostDetailPageState extends State<PostDetailPage> {
           if (replies.isNotEmpty) ...[
             const SizedBox(height: 12),
             Column(
-              children: replies.map((r) {
-                return Padding(
-                  padding: const EdgeInsets.only(left: 0, bottom: 0), // 들여쓰기
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // ㄴ 모양 가이드
-                      Container(
-                        width: 10,
-                        height: 18,
-                        margin: const EdgeInsets.only(right: 0, top: 4,left: 0),
-                        child: SvgPicture.asset(
-                          'assets/icons/board_reply.svg',
-                          width: 11,
-                          height: 15,
-                          colorFilter: const ColorFilter.mode(AppColors.gray300, BlendMode.srcIn),
-                        ),
-                      ),
-
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              r.nickname,
-                              style: const TextStyle(
-                                fontSize: 12,
-                                fontWeight: FontWeight.w600,
-                                color: AppColors.gray800,
+              children:
+                  replies.map((r) {
+                    return Padding(
+                      padding: const EdgeInsets.only(
+                        left: 0,
+                        bottom: 0,
+                      ), // 들여쓰기
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // ㄴ 모양 가이드
+                          Container(
+                            width: 10,
+                            height: 18,
+                            margin: const EdgeInsets.only(
+                              right: 0,
+                              top: 4,
+                              left: 0,
+                            ),
+                            child: SvgPicture.asset(
+                              'assets/icons/board_reply.svg',
+                              width: 11,
+                              height: 15,
+                              colorFilter: const ColorFilter.mode(
+                                AppColors.gray300,
+                                BlendMode.srcIn,
                               ),
                             ),
-                            const SizedBox(height: 4),
-                            Text(
-                              r.body,
-                              style: const TextStyle(
-                                fontSize: 14,
-                                color: AppColors.gray900,
-                                height: 1.5,
-                              ),
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              r.time,
-                              style: const TextStyle(
-                                fontSize: 12,
-                                color: AppColors.gray500,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      Container(
-                        height: 24,
-                        padding: const EdgeInsets.symmetric(horizontal: 0),
-                        decoration: BoxDecoration(
-                          color: AppColors.gray100, // 연한 회색 배경
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
+                          ),
 
-
-                            // 하트 (토글 색상)
-                            _IconButtonBox(
-                              onTap: () {
-                                setState(() {
-                                  c.liked = !c.liked;
-                                  c.liked ? c.likes++ : c.likes--;
-                                });
-                              },
-                              child: SvgPicture.asset(
-                                'assets/icons/board_heart.svg',
-                                width: 14,
-                                height: 12,
-                                colorFilter: ColorFilter.mode(
-                                  c.liked ? AppColors.primary700 : AppColors.gray400,
-                                  BlendMode.srcIn,
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  r.nickname,
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w600,
+                                    color: AppColors.gray800,
+                                  ),
                                 ),
-                              ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  r.body,
+                                  style: const TextStyle(
+                                    fontSize: 14,
+                                    color: AppColors.gray900,
+                                    height: 1.5,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  r.time,
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    color: AppColors.gray500,
+                                  ),
+                                ),
+                              ],
                             ),
-
-                            _VBar(),
-
-                            // 더보기 (세로 점 3개)
-                            _IconButtonBox(
-                              onTap: () {}, // 신고/삭제 등 메뉴 오픈
-                              child: const Icon(Icons.more_vert, size: 14, color: AppColors.gray400),
+                          ),
+                          Container(
+                            height: 24,
+                            padding: const EdgeInsets.symmetric(horizontal: 0),
+                            decoration: BoxDecoration(
+                              color: AppColors.gray100, // 연한 회색 배경
+                              borderRadius: BorderRadius.circular(4),
                             ),
-                          ],
-                        ),
-                      )
-                    ],
-                  ),
-                );
-              }).toList(),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                // 하트 (토글 색상)
+                                _IconButtonBox(
+                                  onTap: () {
+                                    setState(() {
+                                      c.liked = !c.liked;
+                                      c.liked ? c.likes++ : c.likes--;
+                                    });
+                                  },
+                                  child: SvgPicture.asset(
+                                    'assets/icons/board_heart.svg',
+                                    width: 14,
+                                    height: 12,
+                                    colorFilter: ColorFilter.mode(
+                                      c.liked
+                                          ? AppColors.primary700
+                                          : AppColors.gray400,
+                                      BlendMode.srcIn,
+                                    ),
+                                  ),
+                                ),
+
+                                _VBar(),
+
+                                // 더보기 (세로 점 3개)
+                                _IconButtonBox(
+                                  onTap: () {}, // 신고/삭제 등 메뉴 오픈
+                                  child: const Icon(
+                                    Icons.more_vert,
+                                    size: 14,
+                                    color: AppColors.gray400,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }).toList(),
             ),
           ],
-
         ],
       ),
     );
   }
-
 }
-
 
 /// ───────────────────────── 위젯들 ─────────────────────────
 
@@ -575,7 +593,6 @@ class _ActionBar extends StatelessWidget {
         ],
       ),
     );
-
   }
 }
 
@@ -608,7 +625,11 @@ class _InlineAction extends StatelessWidget {
         const SizedBox(width: 4),
         Text(
           label,
-          style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: color),
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: color,
+          ),
         ),
       ],
     );
@@ -636,11 +657,19 @@ class _EmptyComment extends StatelessWidget {
       alignment: Alignment.center,
       child: Column(
         children: [
-          SvgPicture.asset('assets/icons/board_bori.svg', width: 60, height: 60),
+          SvgPicture.asset(
+            'assets/icons/board_bori.svg',
+            width: 60,
+            height: 60,
+          ),
           const SizedBox(height: 24),
           const Text(
             '첫 번째 댓글을 남겨주세요!',
-            style: TextStyle(fontSize: 16, color: AppColors.gray600, fontWeight:FontWeight.w400),
+            style: TextStyle(
+              fontSize: 16,
+              color: AppColors.gray600,
+              fontWeight: FontWeight.w400,
+            ),
           ),
         ],
       ),
@@ -701,9 +730,10 @@ class _CommentInputBar extends StatelessWidget {
                           height: 21.58,
                           width: 32,
                           decoration: BoxDecoration(
-                            color: hasText
-                                ? AppColors.primary700
-                                : const Color(0xFFC0C0C0),
+                            color:
+                                hasText
+                                    ? AppColors.primary700
+                                    : const Color(0xFFC0C0C0),
                             borderRadius: BorderRadius.circular(5.95),
                           ),
                           child: Center(
@@ -721,15 +751,16 @@ class _CommentInputBar extends StatelessWidget {
                       ),
                     ),
                     // ✅ suffixIcon이 TextField 안쪽에 잘 맞게 패딩 조절
-                    suffixIconConstraints:
-                    const BoxConstraints(minWidth: 36, minHeight: 36),
+                    suffixIconConstraints: const BoxConstraints(
+                      minWidth: 36,
+                      minHeight: 36,
+                    ),
                   ),
                 ),
               ),
             ),
           ],
         ),
-
       ),
     );
   }
@@ -742,7 +773,10 @@ class _AvatarSmall extends StatelessWidget {
     return Container(
       width: 24,
       height: 24,
-      decoration: const BoxDecoration(shape: BoxShape.circle, color: Color(0xFFE5E7EB)),
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        color: Color(0xFFE5E7EB),
+      ),
     );
   }
 }
@@ -772,11 +806,7 @@ class _IconButtonBox extends StatelessWidget {
     return InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(8),
-      child: SizedBox(
-        width: 36,
-        height: 36,
-        child: Center(child: child),
-      ),
+      child: SizedBox(width: 36, height: 36, child: Center(child: child)),
     );
   }
 }
@@ -785,7 +815,8 @@ class _VBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 1, height: 16,
+      width: 1,
+      height: 16,
       margin: const EdgeInsets.symmetric(horizontal: 8),
       color: AppColors.gray400,
     );
@@ -808,24 +839,24 @@ class _Reply {
   });
 }
 
-
-
-
 class _ElbowPainter extends CustomPainter {
   final Color color;
   const _ElbowPainter({required this.color});
   @override
   void paint(Canvas canvas, Size size) {
-    final p = Paint()
-      ..color = color
-      ..strokeWidth = 1.0
-      ..style = PaintingStyle.stroke;
-    final path = Path()
-      ..moveTo(size.width - 1, 0)
-      ..lineTo(size.width - 1, size.height - 6)
-      ..lineTo(0, size.height - 6);
+    final p =
+        Paint()
+          ..color = color
+          ..strokeWidth = 1.0
+          ..style = PaintingStyle.stroke;
+    final path =
+        Path()
+          ..moveTo(size.width - 1, 0)
+          ..lineTo(size.width - 1, size.height - 6)
+          ..lineTo(0, size.height - 6);
     canvas.drawPath(path, p);
   }
+
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }
@@ -864,7 +895,6 @@ class _ReplyBottomBar extends StatelessWidget {
                 topLeft: Radius.circular(12),
                 topRight: Radius.circular(12),
               ),
-
             ),
             child: Row(
               children: [
@@ -879,7 +909,6 @@ class _ReplyBottomBar extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
-
               ],
             ),
           ),
@@ -899,7 +928,6 @@ class _ReplyBottomBar extends StatelessWidget {
                         bottomLeft: Radius.circular(12),
                         bottomRight: Radius.circular(12),
                       ),
-
                     ),
                     alignment: Alignment.center,
                     child: TextField(
@@ -929,9 +957,10 @@ class _ReplyBottomBar extends StatelessWidget {
                               height: 21.58,
                               width: 32,
                               decoration: BoxDecoration(
-                                color: hasText
-                                    ? AppColors.primary700
-                                    : const Color(0xFFC0C0C0),
+                                color:
+                                    hasText
+                                        ? AppColors.primary700
+                                        : const Color(0xFFC0C0C0),
                                 borderRadius: BorderRadius.circular(5.95),
                               ),
                               child: Center(
@@ -948,8 +977,10 @@ class _ReplyBottomBar extends StatelessWidget {
                             ),
                           ),
                         ),
-                        suffixIconConstraints:
-                        const BoxConstraints(minWidth: 36, minHeight: 36),
+                        suffixIconConstraints: const BoxConstraints(
+                          minWidth: 36,
+                          minHeight: 36,
+                        ),
                       ),
                     ),
                   ),
@@ -962,7 +993,3 @@ class _ReplyBottomBar extends StatelessWidget {
     );
   }
 }
-
-
-
-

--- a/lib/feature/community/screens/tabs/free_board_tab.dart
+++ b/lib/feature/community/screens/tabs/free_board_tab.dart
@@ -5,6 +5,7 @@ import 'package:inninglog/feature/community/viewmodel/post_list_view_model.dart'
 import 'package:inninglog/feature/community/widgets/post/post_item_card.dart';
 import 'package:inninglog/feature/community/widgets/shared/board_list.dart';
 import 'package:inninglog/router/route_observer.dart';
+import 'package:inninglog/router/app_routes.dart';
 import 'package:inninglog/shared/widgets/empty_state.dart';
 import 'package:provider/provider.dart';
 
@@ -55,7 +56,8 @@ class _FreeBoardTabState extends State<FreeBoardTab> with RouteAware {
     final route = ModalRoute.of(context);
     if (route == null) return;
 
-    final observers = route.navigator?.widget.observers ?? const <NavigatorObserver>[];
+    final observers =
+        route.navigator?.widget.observers ?? const <NavigatorObserver>[];
 
     if (observers.contains(shellRouteObserver)) {
       shellRouteObserver.subscribe(this, route);
@@ -84,7 +86,10 @@ class _FreeBoardTabState extends State<FreeBoardTab> with RouteAware {
                 item: item,
                 onTap:
                     () => context.push(
-                      '/boards/${widget.teamCode}/post/${item.id}',
+                      AppRoutePaths.boardPostDetailLocation(
+                        widget.teamCode,
+                        item.id,
+                      ),
                     ),
               ),
         );

--- a/lib/feature/community/viewmodel/post_detail_view_model.dart
+++ b/lib/feature/community/viewmodel/post_detail_view_model.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/model/community_post.dart';
+import 'package:inninglog/feature/community/repositories/post_repository.dart';
+
+class PostDetailViewModel extends ChangeNotifier {
+  final CommunityPostRepository repo;
+  final int postId;
+
+  PostDetailViewModel({
+    required this.repo,
+    required this.postId,
+  });
+
+  CommunityPostItem? _post;
+  CommunityPostItem? get post => _post;
+
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
+
+  String? _error;
+  String? get error => _error;
+
+  bool _likedByMe = false;
+  bool get likedByMe => _likedByMe;
+
+  int _likeCount = 0;
+  int get likeCount => _likeCount;
+
+  bool _scrapedByMe = false;
+  bool get scrapedByMe => _scrapedByMe;
+
+  int _scrapCount = 0;
+  int get scrapCount => _scrapCount;
+
+  int _commentCount = 0;
+  int get commentCount => _commentCount;
+
+  Future<void> fetch() async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final res = await repo.getPostDetail(postId: postId);
+      _post = res;
+      _likedByMe = res.likedByMe;
+      _likeCount = res.likeCount;
+      _scrapedByMe = res.scrapedByMe;
+      _scrapCount = res.scrapCount;
+      _commentCount = res.commentCount;
+      _error = null;
+    } catch (e) {
+      _error = e.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> toggleLike() async {
+    final prevLiked = _likedByMe;
+    final prevCount = _likeCount;
+    _likedByMe = !_likedByMe;
+    _likeCount += _likedByMe ? 1 : -1;
+    if (_likeCount < 0) _likeCount = 0;
+    notifyListeners();
+
+    try {
+      if (_likedByMe) {
+        await repo.likePost(postId: postId);
+      } else {
+        await repo.unlikePost(postId: postId);
+      }
+    } catch (e) {
+      _likedByMe = prevLiked;
+      _likeCount = prevCount;
+      _error = e.toString();
+      notifyListeners();
+    }
+  }
+
+  Future<void> toggleScrap() async {
+    final prevScraped = _scrapedByMe;
+    final prevCount = _scrapCount;
+    _scrapedByMe = !_scrapedByMe;
+    _scrapCount += _scrapedByMe ? 1 : -1;
+    if (_scrapCount < 0) _scrapCount = 0;
+    notifyListeners();
+
+    try {
+      if (_scrapedByMe) {
+        await repo.scrapPost(postId: postId);
+      } else {
+        await repo.unscrapPost(postId: postId);
+      }
+    } catch (e) {
+      _scrapedByMe = prevScraped;
+      _scrapCount = prevCount;
+      _error = e.toString();
+      notifyListeners();
+    }
+  }
+}

--- a/lib/feature/community/widgets/post/post_item_card.dart
+++ b/lib/feature/community/widgets/post/post_item_card.dart
@@ -69,7 +69,7 @@ class PostItemCard extends StatelessWidget {
                       ],
                     ),
                     const SizedBox(height: 10),
-                    PostTitle(text: item.title),
+                    PostTitle(text: item.title, isPreview: true),
                     const SizedBox(height: 4),
                     PostBody(text: item.content, isPreview: true),
                     const SizedBox(height: 8),

--- a/lib/feature/community/widgets/post/post_texts.dart
+++ b/lib/feature/community/widgets/post/post_texts.dart
@@ -5,15 +5,24 @@ import 'package:inninglog/shared/theme/app_text_styles.dart';
 class PostTitle extends StatelessWidget {
   final String text;
   final int maxLines;
+  final bool isPreview;
 
-  const PostTitle({required this.text, this.maxLines = 1, super.key});
+  const PostTitle({
+    required this.text,
+    this.maxLines = 1,
+    this.isPreview = false,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final titleTextStyle =
+        isPreview ? AppTextStyles.headHead6B : AppTextStyles.headHead4B;
+
     return _PostText(
       text,
       maxLines: maxLines,
-      style: AppTextStyles.headHead6B.copyWith(color: AppColors.gray900),
+      style: titleTextStyle.copyWith(color: AppColors.gray900),
     );
   }
 }
@@ -46,10 +55,12 @@ class PostBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bodyTextStyle =
+        isPreview ? AppTextStyles.bodyBody2M : AppTextStyles.bodyBody1Rg;
     return _PostText(
       text,
       maxLines: isPreview ? 1 : null,
-      style: AppTextStyles.bodyBody2M.copyWith(color: AppColors.gray900),
+      style: bodyTextStyle.copyWith(color: AppColors.gray900),
     );
   }
 }

--- a/lib/feature/community/widgets/post_detail/post_action_bar.dart
+++ b/lib/feature/community/widgets/post_detail/post_action_bar.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/widgets/post_detail/post_action_button.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+
+class PostActionBar extends StatelessWidget {
+  final bool likeActive;
+  final int likeCount;
+  final VoidCallback onTapLike;
+
+  final bool scrapActive;
+  final int scrapCount;
+  final VoidCallback onTapScrap;
+
+  final int commentCount;
+
+  const PostActionBar({
+    super.key,
+    required this.likeActive,
+    required this.likeCount,
+    required this.onTapLike,
+    required this.scrapActive,
+    required this.scrapCount,
+    required this.onTapScrap,
+    required this.commentCount,
+  });
+
+  String _labelWithCount(String base, int count) {
+    // 0이면 숫자 미표시, 그 외엔 "base n"
+    return count <= 0 ? base : '$base $count';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        border: Border(top: BorderSide(color: AppColors.gray300, width: 1)),
+      ),
+      padding: EdgeInsets.symmetric(vertical: 12),
+      child: Row(
+        children: [
+          // 공감
+          Expanded(
+            child: Center(
+              child: PostActionButton(
+                asset: 'assets/icons/board_heart.svg',
+                color: likeActive ? AppColors.primary700 : AppColors.gray500,
+                label: _labelWithCount('공감', likeCount),
+                onTap: onTapLike,
+                iconSize: 18,
+              ),
+            ),
+          ),
+
+          // 댓글 (항상 회색, 숫자만 변화)
+          Expanded(
+            child: Center(
+              child: PostActionButton(
+                asset: 'assets/icons/board_comment.svg',
+                color: AppColors.gray500,
+                label: _labelWithCount('댓글', commentCount),
+                onTap: null,
+                iconSize: 18,
+              ),
+            ),
+          ),
+
+          // 스크랩
+          Expanded(
+            child: Center(
+              child: PostActionButton(
+                asset: 'assets/icons/board_scrap.svg',
+                color: scrapActive ? AppColors.primary700 : AppColors.gray500,
+                label: _labelWithCount('스크랩', scrapCount),
+                onTap: onTapScrap,
+                iconSize: 18,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/post_detail/post_action_button.dart
+++ b/lib/feature/community/widgets/post_detail/post_action_button.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+class PostActionButton extends StatelessWidget {
+  final String asset;
+  final String label;
+  final Color color;
+  final VoidCallback? onTap;
+  final double iconSize;
+
+  const PostActionButton({
+    super.key,
+    required this.asset,
+    required this.label,
+    required this.color,
+    required this.onTap,
+    this.iconSize = 18,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final content = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SvgPicture.asset(
+          asset,
+          width: iconSize,
+          height: iconSize,
+          colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
+        ),
+        const SizedBox(width: 4),
+        Text(label, style: AppTextStyles.headHead8Sb.copyWith(color: color)),
+      ],
+    );
+
+    if (onTap == null) return content;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+        child: content,
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/post_detail/post_detail_app_bar.dart
+++ b/lib/feature/community/widgets/post_detail/post_detail_app_bar.dart
@@ -45,7 +45,7 @@ class PostDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
       trailing:
           showMore
               ? IconButton(
-                icon: SvgPicture.asset(moreIconAsset, width: 18),
+                icon: SvgPicture.asset(moreIconAsset, width: 36),
                 onPressed: onTapMore ?? () {},
               )
               : null,

--- a/lib/feature/community/widgets/post_detail/post_detail_app_bar.dart
+++ b/lib/feature/community/widgets/post_detail/post_detail_app_bar.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/feature/community/widgets/shared/board_header_bar.dart';
+
+class PostDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String teamLabel;
+
+  /// 상단 첫 줄 타이틀 (기본: 자유 게시판)
+  final String boardTitle;
+
+  /// 뒤로가기 탭
+  final VoidCallback? onBack;
+
+  /// 우측 더보기 탭
+  final VoidCallback? onTapMore;
+
+  /// 아이콘 에셋 경로 (프로젝트 기본값 유지)
+  final String backIconAsset;
+  final String moreIconAsset;
+
+  /// 우측 액션 노출 여부
+  final bool showMore;
+
+  const PostDetailAppBar({
+    super.key,
+    required this.teamLabel,
+    this.boardTitle = '자유 게시판',
+    this.onBack,
+    this.onTapMore,
+    this.backIconAsset = 'assets/icons/back_but.svg',
+    this.moreIconAsset = 'assets/icons/board_dots.svg',
+    this.showMore = true,
+  });
+
+  @override
+  Size get preferredSize => const Size.fromHeight(64);
+
+  @override
+  Widget build(BuildContext context) {
+    return BoardHeaderBar(
+      title: boardTitle,
+      subtitle: teamLabel,
+      leadingIconAsset: backIconAsset,
+      onTapLeading: onBack ?? () => Navigator.pop(context),
+      trailing:
+          showMore
+              ? IconButton(
+                icon: SvgPicture.asset(moreIconAsset, width: 18),
+                onPressed: onTapMore ?? () {},
+              )
+              : null,
+      backgroundColor: Colors.white,
+      // height: 72,
+    );
+  }
+}

--- a/lib/feature/community/widgets/post_detail/post_header_section.dart
+++ b/lib/feature/community/widgets/post_detail/post_header_section.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/widgets/post/post_texts.dart';
+import 'package:inninglog/feature/community/widgets/post_detail/post_image_gallery.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+import 'package:inninglog/shared/utils/date_time_utils.dart';
+
+class PostSection extends StatelessWidget {
+  // 작성자/메타
+  final String nickName;
+  final String createAt;
+
+  // 컨텐츠
+  final String title;
+  final String content;
+
+  /// (선택) 프로필 이미지 위젯을 주입받고 싶을 때
+  /// - 안 주면 기본 원형 플레이스홀더가 노출됨
+  final String? profileUrl;
+
+  final List<String> imageUrls;
+
+  const PostSection({
+    super.key,
+    required this.nickName,
+    required this.createAt,
+    required this.title,
+    required this.content,
+    this.imageUrls = const [],
+    this.profileUrl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final trimmedTitle = title.trim();
+    final trimmedBody = content.trim();
+
+    return Container(
+      color: AppColors.primary50,
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          PostAuthorRow(
+            createAt: createAt,
+            nickName: nickName,
+            profileUrl: profileUrl,
+          ),
+          const SizedBox(height: 16),
+
+          if (trimmedTitle.isNotEmpty) ...[
+            PostTitle(text: trimmedTitle),
+            const SizedBox(height: 16),
+          ],
+
+          if (trimmedBody.isNotEmpty) PostBody(text: trimmedBody),
+          if (imageUrls.isNotEmpty) PostImageGallery(imageUrls: imageUrls),
+        ],
+      ),
+    );
+  }
+}
+
+class PostAuthorRow extends StatelessWidget {
+  final String nickName;
+  final String createAt;
+  final String? profileUrl;
+
+  const PostAuthorRow({
+    super.key,
+    required this.nickName,
+    required this.createAt,
+    this.profileUrl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      spacing: 8,
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: const BoxDecoration(
+            color: Color(0xFFE5E7EB),
+            shape: BoxShape.circle,
+          ),
+          clipBehavior: Clip.antiAlias,
+          child:
+              (profileUrl != null && profileUrl!.isNotEmpty)
+                  ? Image.network(profileUrl!, fit: BoxFit.cover)
+                  : null,
+        ),
+        Column(
+          spacing: 8,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              nickName,
+              style: AppTextStyles.headHead7Sb.copyWith(
+                color: AppColors.gray800,
+              ),
+            ),
+            Text(
+              DateTimeUtils.formatToKoreanDateTimeShort(createAt),
+              style: AppTextStyles.headHead8M.copyWith(
+                color: AppColors.gray700,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/feature/community/widgets/post_detail/post_image_gallery.dart
+++ b/lib/feature/community/widgets/post_detail/post_image_gallery.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+
+class PostImageGallery extends StatelessWidget {
+  final List<String> imageUrls;
+
+  /// 갤러리 높이 (고정)
+  final double height;
+
+  /// 모서리 라운드
+  final double radius;
+
+  const PostImageGallery({
+    super.key,
+    required this.imageUrls,
+    this.height = 220,
+    this.radius = 8,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final urls = imageUrls;
+    if (urls.isEmpty) return const SizedBox.shrink();
+
+    // ✅ 1장일 때는 그냥 단일 이미지
+    if (urls.length == 1) {
+      return _ImageCard(url: urls.first, height: height, radius: radius);
+    }
+
+    // ✅ 2장 이상: 가로 스크롤
+    return SizedBox(
+      height: height,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: EdgeInsets.zero,
+        itemCount: urls.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 8),
+        itemBuilder: (_, i) {
+          return SizedBox(
+            width: MediaQuery.of(context).size.width - 32, // 기본 여백 고려
+            child: _ImageCard(url: urls[i], height: height, radius: radius),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ImageCard extends StatelessWidget {
+  final String url;
+  final double height;
+  final double radius;
+
+  const _ImageCard({
+    required this.url,
+    required this.height,
+    required this.radius,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final img = Image.network(
+      url,
+      fit: BoxFit.cover,
+      width: double.infinity,
+      height: height,
+      loadingBuilder: (context, child, loadingProgress) {
+        if (loadingProgress == null) return child;
+        return Container(
+          color: AppColors.gray100,
+          alignment: Alignment.center,
+          child: const SizedBox(
+            width: 18,
+            height: 18,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        );
+      },
+      errorBuilder: (_, __, ___) {
+        return Container(
+          color: AppColors.gray100,
+          alignment: Alignment.center,
+          child: const Icon(
+            Icons.broken_image_outlined,
+            color: AppColors.gray500,
+          ),
+        );
+      },
+    );
+
+    if (radius <= 0) return img;
+
+    return ClipRRect(borderRadius: BorderRadius.circular(radius), child: img);
+  }
+}

--- a/lib/feature/community/widgets/root/components/popular_post_card.dart
+++ b/lib/feature/community/widgets/root/components/popular_post_card.dart
@@ -23,7 +23,7 @@ class PopularPostCard extends StatelessWidget {
         children: [
           Row(
             children: [
-              Expanded(child: PostTitle(text: post.title)),
+              Expanded(child: PostTitle(text: post.title, isPreview: true)),
               const SizedBox(width: 8),
               PostDateTimeText(text: post.dateTime),
             ],

--- a/lib/feature/community/widgets/shared/board_header_bar.dart
+++ b/lib/feature/community/widgets/shared/board_header_bar.dart
@@ -5,14 +5,23 @@ import 'package:inninglog/shared/theme/app_text_styles.dart';
 
 /// 공통 게시판 헤더: 좌측 아이콘, 중앙 타이틀/서브타이틀, 우측 액션을 재사용하도록 구성.
 class BoardHeaderBar extends StatelessWidget implements PreferredSizeWidget {
+  /// 중앙에 표시할 메인 타이틀 텍스트.
   final String title;
+  /// 타이틀 하단에 표시할 서브타이틀 텍스트.
   final String subtitle;
+  /// 좌측 아이콘의 SVG 에셋 경로.
   final String leadingIconAsset;
+  /// 좌측 아이콘 크기.
   final Size leadingIconSize;
+  /// 좌측 아이콘 탭 콜백.
   final VoidCallback onTapLeading;
+  /// 우측에 배치할 커스텀 위젯(없으면 좌측 폭과 동일한 여백).
   final Widget? trailing;
+  /// 헤더 전체 높이.
   final double height;
+  /// 좌측 아이콘 영역의 고정 폭.
   final double leadingWidth;
+  /// 헤더 배경색.
   final Color backgroundColor;
 
   const BoardHeaderBar({

--- a/lib/feature/community/widgets/shared/board_header_bar.dart
+++ b/lib/feature/community/widgets/shared/board_header_bar.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+/// 공통 게시판 헤더: 좌측 아이콘, 중앙 타이틀/서브타이틀, 우측 액션을 재사용하도록 구성.
+class BoardHeaderBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final String subtitle;
+  final String leadingIconAsset;
+  final Size leadingIconSize;
+  final VoidCallback onTapLeading;
+  final Widget? trailing;
+  final double height;
+  final double leadingWidth;
+  final Color backgroundColor;
+
+  const BoardHeaderBar({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.leadingIconAsset,
+    required this.onTapLeading,
+    this.trailing,
+    this.leadingIconSize = const Size(10, 20),
+    this.height = 64,
+    this.leadingWidth = 54,
+    this.backgroundColor = Colors.white,
+  });
+
+  @override
+  Size get preferredSize => Size.fromHeight(height);
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: true,
+      bottom: false,
+      child: Container(
+        height: height,
+        color: backgroundColor,
+        child: Row(
+          children: [
+            SizedBox(
+              width: leadingWidth,
+              child: IconButton(
+                onPressed: onTapLeading,
+                icon: SvgPicture.asset(
+                  leadingIconAsset,
+                  width: leadingIconSize.width,
+                  height: leadingIconSize.height,
+                ),
+              ),
+            ),
+            const Spacer(),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  title,
+                  style: AppTextStyles.headHead4EB.copyWith(
+                    color: AppColors.gray900,
+                  ),
+                ),
+                Text(
+                  subtitle,
+                  style: AppTextStyles.bodyBody2M.copyWith(
+                    color: AppColors.gray700,
+                  ),
+                ),
+              ],
+            ),
+            const Spacer(),
+            trailing ?? SizedBox(width: leadingWidth),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/writing_post/writing_post_app_bar.dart
+++ b/lib/feature/community/widgets/writing_post/writing_post_app_bar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
 import 'package:inninglog/shared/theme/app_text_styles.dart';
+import 'package:inninglog/feature/community/widgets/shared/board_header_bar.dart';
 
 class WritingPostAppBar extends StatelessWidget {
   final String teamLabel;
@@ -19,67 +19,42 @@ class WritingPostAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 72,
-      alignment: Alignment.center,
-      child: Row(
-        children: [
-          IconButton(
-            onPressed: onClose,
-            icon: SvgPicture.asset(
-              'assets/icons/cancel_button.svg',
-              width: 15,
-              height: 15,
-            ),
-          ),
-          const Spacer(),
-          Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(
-                '글쓰기',
-                style: AppTextStyles.headHead4EB.copyWith(
-                  color: AppColors.gray900,
-                ),
-              ),
-              Text(
-                teamLabel,
-                style: AppTextStyles.bodyBody2M.copyWith(
-                  color: AppColors.gray700,
-                ),
-              ),
-            ],
-          ),
-          const Spacer(),
-          TextButton(
-            onPressed: isSubmitEnabled ? onSubmit : null,
-            style: ButtonStyle(
-              foregroundColor: WidgetStateProperty.resolveWith<Color>((states) {
-                if (states.contains(WidgetState.disabled)) {
-                  return AppColors.gray700;
-                }
-                return AppColors.primary700;
-              }),
-              padding: WidgetStateProperty.all(
-                const EdgeInsets.symmetric(horizontal: 0, vertical: 8),
-              ),
-              textStyle: WidgetStateProperty.resolveWith<TextStyle>((states) {
-                final isDisabled = states.contains(WidgetState.disabled);
-                return AppTextStyles.bodyBody1Rg.copyWith(
-                  fontWeight: isDisabled ? FontWeight.w400 : FontWeight.w700,
-                );
-              }),
-              overlayColor: WidgetStateProperty.resolveWith<Color?>((states) {
-                if (states.contains(WidgetState.disabled)) {
-                  return Colors.transparent;
-                }
-                return null;
-              }),
-            ),
-            child: const Text('등록'),
-          ),
-        ],
+    final submitButton = TextButton(
+      onPressed: isSubmitEnabled ? onSubmit : null,
+      style: ButtonStyle(
+        foregroundColor: WidgetStateProperty.resolveWith<Color>((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return AppColors.gray700;
+          }
+          return AppColors.primary700;
+        }),
+        padding: WidgetStateProperty.all(
+          const EdgeInsets.symmetric(horizontal: 0, vertical: 8),
+        ),
+        textStyle: WidgetStateProperty.resolveWith<TextStyle>((states) {
+          final isDisabled = states.contains(WidgetState.disabled);
+          return AppTextStyles.bodyBody1Rg.copyWith(
+            fontWeight: isDisabled ? FontWeight.w400 : FontWeight.w700,
+          );
+        }),
+        overlayColor: WidgetStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return Colors.transparent;
+          }
+          return null;
+        }),
       ),
+      child: const Text('등록'),
+    );
+
+    return BoardHeaderBar(
+      title: '글쓰기',
+      subtitle: teamLabel,
+      leadingIconAsset: 'assets/icons/cancel_button.svg',
+      leadingIconSize: const Size(15, 15),
+      onTapLeading: onClose,
+      trailing: submitButton,
+      // height: 72,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,14 +75,6 @@ final GoRouter _router = GoRouter(
       builder: (context, state) => const KakaoLoginWebViewPage(),
     ),
 
-    // 커뮤니티 게시글 작성 페이지
-    GoRoute(
-      path: AppRoutePaths.postWrite,
-      builder: (context, state) {
-        return WritingPostPage(teamCode: 'ALL');
-      },
-    ),
-
     GoRoute(path: '/splash', builder: (_, __) => const SplashScreen()),
     GoRoute(path: '/onboarding', builder: (_, __) => const OnboardingScreen()),
 
@@ -210,8 +202,6 @@ final GoRouter _router = GoRouter(
           path: AppRoutePaths.board,
           builder: (_, state) {
             final code = state.pathParameters['code']!; // 팀 코드
-            final tabStr = state.uri.queryParameters['tab']; // 쿼리로 탭 받기
-            final initialTabIndex = int.tryParse(tabStr ?? '') ?? 0;
             final tabParam = int.tryParse(
               state.uri.queryParameters['tab'] ?? '',
             );
@@ -225,27 +215,20 @@ final GoRouter _router = GoRouter(
             GoRoute(
               path: AppRoutePaths.boardPostWrite,
               name: 'writing_post',
+              parentNavigatorKey: _rootNavigatorKey, // GNB 없는 화면
               builder: (_, state) {
                 final code = state.pathParameters['code']!;
                 return WritingPostPage(teamCode: code);
               },
             ),
             GoRoute(
-              path: 'posts/:postId',
+              path: AppRoutePaths.boardPostDetail,
               name: 'post_detail',
+              parentNavigatorKey: _rootNavigatorKey, // GNB 없는 화면
               builder: (context, state) {
                 final teamCode = state.pathParameters['code']!;
                 final postId = int.parse(state.pathParameters['postId']!);
-                final teamLabel =
-                    (state.extra as Map?)?['teamLabel'] as String? ?? '';
-                return PostDetailPage(
-                  // 네 상세 위젯으로 바꾸세요
-                  args: PostDetailArgs(
-                    teamCode: teamCode,
-                    teamLabel: teamLabel,
-                    postId: postId,
-                  ),
-                );
+                return PostDetailPage(teamCode: teamCode, postId: postId);
               },
             ),
           ],

--- a/lib/router/app_routes.dart
+++ b/lib/router/app_routes.dart
@@ -4,9 +4,13 @@ import 'package:flutter/foundation.dart';
 final class AppRoutePaths {
   const AppRoutePaths._();
 
-  static const postWrite = '/post/new'; // GNB 없는 legacy 글쓰기
-  static const boardPostWrite = 'post/new'; // /boards/:code 하위 상대경로
+  // 팀 게시판 루트 (/boards/:code)
   static const board = '/boards/:code';
+  // 팀 게시판 내 글쓰기 (ShellRoute 하위 상대 경로)
+  static const boardPostWrite = 'post/new';
+  // 게시판 상세 포스트 (중첩 라우터에서 상대 경로)
+  static const boardPostDetail = 'posts/:postId';
+  // 커뮤니티 검색
   static const search = '/search';
 
   static String boardLocation(String code, {int? tab}) {
@@ -14,5 +18,9 @@ final class AppRoutePaths {
     return '/boards/$code$tabQuery';
   }
 
+  // 절대 경로: 팀 게시판 글쓰기
   static String boardPostWriteLocation(String code) => '/boards/$code/post/new';
+  // 절대 경로: 팀 게시판 게시글 상세
+  static String boardPostDetailLocation(String code, int postId) =>
+      '/boards/$code/posts/$postId';
 }

--- a/lib/shared/utils/date_time_utils.dart
+++ b/lib/shared/utils/date_time_utils.dart
@@ -20,6 +20,24 @@ class DateTimeUtils {
     return '$year/$month/$day($weekday) $hour:$minute';
   }
 
+  /// Formats a date string into "MM/dd(E) HH:mm" (e.g., "05/25(일) 11:02").
+  /// Returns the original [dateTimeString] if parsing fails.
+  static String formatToKoreanDateTimeShort(String dateTimeString) {
+    final parsed = _parse(dateTimeString);
+    if (parsed == null) return dateTimeString;
+    return formatDateTimeShort(parsed);
+  }
+
+  /// Formats a [DateTime] into "MM/dd(E) HH:mm" with Korean weekday.
+  static String formatDateTimeShort(DateTime dateTime) {
+    final month = dateTime.month.toString().padLeft(2, '0');
+    final day = dateTime.day.toString().padLeft(2, '0');
+    final weekday = _weekdaysKo[(dateTime.weekday - 1) % 7];
+    final hour = dateTime.hour.toString().padLeft(2, '0');
+    final minute = dateTime.minute.toString().padLeft(2, '0');
+    return '$month/$day($weekday) $hour:$minute';
+  }
+
   static DateTime? _parse(String raw) {
     final trimmed = raw.trim();
     if (trimmed.isEmpty) return null;


### PR DESCRIPTION
## 🎯요약(Summary)
- 커뮤니티 Post 상세 화면에서 댓글 제외 상단 UI 구현 및 API 연동을 진행했습니다.

## 💻 상세 내용(Describe your changes)
- PostDetailPage에서 분리 가능한 위젯 분리
- Post 상세/좋아요/스크랩/좋아요취소/스크랩취소 API 함수 작성 및 연동
- 게시글 타이틀, 바디는 미리보기 시 화면 너비에 따라 말줄임표 처리

## 📸 스크린샷
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/56070335-a5a2-4cf9-b1b4-762a200e8227" />

## 📌 관련 이슈번호(Related Issue)
- closed: #66 

## ✅ TODO
- [ ] 자유게시판 탭 복귀 시 최신 데이터 페치하지 않는 버그 해결 
- [ ] 댓글 UI & API 연동
