### PR TITLE
[FIX] 자유게시판 탭 복귀 시 최신 데이터 페치 되지 않는 이슈 해결

### DIFF
--- a/lib/feature/community/screens/root_page.dart
+++ b/lib/feature/community/screens/root_page.dart
@@ -58,9 +58,7 @@ class _CommunityRootView extends StatelessWidget {
               title: 'MY TEAM',
               imagePath: kboTeamBannerCatalog[vm.myTeamCode] ?? '',
               onTap: () {
-                context.push(
-                  AppRoutePaths.boardLocation(vm.myTeamCode ?? 'OB'),
-                );
+                context.push(AppRoutePaths.boardLocation(vm.myTeamCode ?? ''));
               },
             ),
             //전체 게시판

--- a/lib/feature/community/screens/tabs/free_board_tab.dart
+++ b/lib/feature/community/screens/tabs/free_board_tab.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:inninglog/app_scope.dart';
 import 'package:inninglog/feature/community/model/community_post.dart';
 import 'package:inninglog/feature/community/viewmodel/post_list_view_model.dart';
 import 'package:inninglog/feature/community/widgets/post/post_item_card.dart';
@@ -11,7 +12,12 @@ import 'package:provider/provider.dart';
 
 class FreeBoardTab extends StatefulWidget {
   final String teamCode;
-  const FreeBoardTab({super.key, required this.teamCode});
+  final bool isActive;
+  const FreeBoardTab({
+    super.key,
+    required this.teamCode,
+    this.isActive = false,
+  });
 
   @override
   State<FreeBoardTab> createState() => _FreeBoardTabState();
@@ -20,16 +26,36 @@ class FreeBoardTab extends StatefulWidget {
 class _FreeBoardTabState extends State<FreeBoardTab> with RouteAware {
   bool _initialized = false;
   NavigatorObserver? _subscribedObserver;
+  late final PostListViewModel _vm;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!_initialized) {
       _initialized = true;
-      context.read<PostListViewModel>().ensureLoaded();
+      // 탭 최초 진입 시 한 번만 초기 목록을 불러온다.
+      _vm.ensureLoaded();
     }
 
+    // 상세/작성 페이지에서 돌아올 때 pop 이벤트를 받을 수 있도록
+    // 현재 네비게이터에 맞는 observer를 구독한다.
     _subscribeRouteObserver();
+  }
+
+  @override
+  void didUpdateWidget(covariant FreeBoardTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // 다른 탭에서 자유게시판 탭으로 복귀하면 최신 데이터로 갱신한다.
+    if (!oldWidget.isActive && widget.isActive) {
+      _vm.refresh();
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    final repo = context.read<AppScope>().communityPostRepository;
+    _vm = PostListViewModel(repo: repo, teamCode: widget.teamCode);
   }
 
   @override
@@ -42,13 +68,15 @@ class _FreeBoardTabState extends State<FreeBoardTab> with RouteAware {
         rootRouteObserver.unsubscribe(this);
       }
     }
+    _vm.dispose();
     super.dispose();
   }
 
   @override
   void didPopNext() {
     if (!mounted) return;
-    context.read<PostListViewModel>().refresh();
+    // 상세/작성 화면에서 뒤로가기(pop)로 돌아오면 목록을 새로고침한다.
+    _vm.refresh();
   }
 
   void _subscribeRouteObserver() {
@@ -60,40 +88,41 @@ class _FreeBoardTabState extends State<FreeBoardTab> with RouteAware {
         route.navigator?.widget.observers ?? const <NavigatorObserver>[];
 
     if (observers.contains(shellRouteObserver)) {
+      // ShellRoute 내부라면 shell observer를 우선 사용한다.
       shellRouteObserver.subscribe(this, route);
       _subscribedObserver = shellRouteObserver;
-    } else if (observers.contains(rootRouteObserver)) {
-      rootRouteObserver.subscribe(this, route);
-      _subscribedObserver = rootRouteObserver;
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<PostListViewModel>(
-      builder: (context, vm, _) {
-        if (vm.items.isEmpty && !vm.isLoading) {
-          return const EmptyState(message: '게시물이 없습니다.');
-        }
+    return ChangeNotifierProvider.value(
+      value: _vm,
+      child: Consumer<PostListViewModel>(
+        builder: (context, vm, _) {
+          if (vm.items.isEmpty && !vm.isLoading) {
+            return const EmptyState(message: '게시물이 없습니다.');
+          }
 
-        return BoardList<CommunityPostItem>(
-          items: vm.items,
-          hasNext: vm.hasNext,
-          isLoading: vm.isLoading,
-          onLoadMore: vm.loadMore,
-          itemBuilder:
-              (context, item) => PostItemCard(
-                item: item,
-                onTap:
-                    () => context.push(
-                      AppRoutePaths.boardPostDetailLocation(
-                        widget.teamCode,
-                        item.id,
+          return BoardList<CommunityPostItem>(
+            items: vm.items,
+            hasNext: vm.hasNext,
+            isLoading: vm.isLoading,
+            onLoadMore: vm.loadMore,
+            itemBuilder:
+                (context, item) => PostItemCard(
+                  item: item,
+                  onTap:
+                      () => context.push(
+                        AppRoutePaths.boardPostDetailLocation(
+                          widget.teamCode,
+                          item.id,
+                        ),
                       ),
-                    ),
-              ),
-        );
-      },
+                ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/feature/community/screens/teamboard_page.dart
+++ b/lib/feature/community/screens/teamboard_page.dart
@@ -1,29 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
-import 'package:inninglog/app_scope.dart';
 import 'package:inninglog/feature/community/data/tabs_config.dart';
 import 'package:inninglog/feature/community/data/team_catalog.dart';
-import 'package:inninglog/feature/community/viewmodel/post_list_view_model.dart';
 import 'package:inninglog/feature/community/widgets/shared/segmented_tabs.dart';
 import 'package:inninglog/router/app_routes.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
 import 'package:inninglog/feature/community/screens/post_detail_market.dart';
 import 'package:inninglog/shared/widgets/common_header.dart';
-import 'package:provider/provider.dart';
 import 'tabs/free_board_tab.dart';
 
 enum BoardMode { normal, myPosts, myComments, scraps }
 
 class TeamBoardPage extends StatefulWidget {
   final String teamCode; // e.g. 'HT', 'LG', ...
-  final int initialTabIndex;
+  final BoardTab? activeTab;
   final BoardMode mode;
 
   const TeamBoardPage({
     super.key,
     required this.teamCode,
-    this.initialTabIndex = 0,
+    this.activeTab,
     this.mode = BoardMode.normal,
   });
 
@@ -35,6 +32,7 @@ class _TeamBoardPageState extends State<TeamBoardPage>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
   late final List<CommunityTabItem> _tabs;
+  bool _isSyncingRoute = false;
 
   @override
   void initState() {
@@ -42,7 +40,7 @@ class _TeamBoardPageState extends State<TeamBoardPage>
 
     _tabs = communityTabsByMode(widget.mode);
 
-    final safeIndex = widget.initialTabIndex.clamp(0, _tabs.length - 1);
+    final safeIndex = _resolveTabIndex(widget.activeTab);
 
     _tabController = TabController(
       length: _tabs.length,
@@ -50,10 +48,7 @@ class _TeamBoardPageState extends State<TeamBoardPage>
       initialIndex: safeIndex,
     );
 
-    _tabController.addListener(() {
-      if (_tabController.indexIsChanging) return;
-      setState(() {});
-    });
+    _tabController.addListener(_handleTabChange);
   }
 
   @override
@@ -63,71 +58,90 @@ class _TeamBoardPageState extends State<TeamBoardPage>
   }
 
   @override
+  void didUpdateWidget(covariant TeamBoardPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.activeTab != widget.activeTab) {
+      final nextIndex = _resolveTabIndex(widget.activeTab);
+      if (_tabController.index != nextIndex) {
+        _isSyncingRoute = true;
+        _tabController.index = nextIndex;
+        _isSyncingRoute = false;
+      }
+    }
+  }
+
+  int _resolveTabIndex(BoardTab? tab) {
+    final resolvedTab = tab ?? BoardTab.onlywan;
+    final index = _tabs.indexWhere((item) => item.type == resolvedTab);
+    if (index >= 0) return index;
+    return 0;
+  }
+
+  void _handleTabChange() {
+    if (_tabController.indexIsChanging || _isSyncingRoute) return;
+    if (widget.mode != BoardMode.normal) return;
+    final tabType = _tabs[_tabController.index].type;
+    final tabPath = boardTabPath(tabType);
+    context.go(AppRoutePaths.boardLocation(widget.teamCode, tab: tabPath));
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create:
-          (_) => PostListViewModel(
-            repo: context.read<AppScope>().communityPostRepository,
-            teamCode: widget.teamCode,
-          ),
-      child: Scaffold(
-        backgroundColor: AppColors.primary50,
-        floatingActionButton: SizedBox(
-          width: 56,
-          height: 56,
+    return Scaffold(
+      backgroundColor: AppColors.primary50,
+      floatingActionButton: SizedBox(
+        width: 56,
+        height: 56,
 
-          child: FloatingActionButton(
-            backgroundColor: AppColors.primary700,
-            shape: const CircleBorder(),
-            onPressed: () {
-              // 기존 게시판 글쓰기
-              context.push(
-                AppRoutePaths.boardPostWriteLocation(widget.teamCode),
-              );
-              debugPrint('[Team Board Page] teamCode: ${widget.teamCode}');
-            },
-            child: const Icon(Icons.add, size: 40, color: AppColors.primary50),
-          ),
+        child: FloatingActionButton(
+          backgroundColor: AppColors.primary700,
+          shape: const CircleBorder(),
+          onPressed: () {
+            // 기존 게시판 글쓰기
+            context.push(AppRoutePaths.boardPostWriteLocation(widget.teamCode));
+            debugPrint('[Team Board Page] teamCode: ${widget.teamCode}');
+          },
+          child: const Icon(Icons.add, size: 40, color: AppColors.primary50),
         ),
+      ),
 
-        body: SafeArea(
-          child: Column(
-            children: [
-              // 상단 헤더 (뒤로가기 포함)
-              CommonHeader(
-                title:
-                    widget.teamCode == 'ALL'
-                        ? '전체 게시판'
-                        : kboTeamLabelOf(widget.teamCode),
-                onSearchPressed: () => context.push(AppRoutePaths.search),
-              ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            // 상단 헤더 (뒤로가기 포함)
+            CommonHeader(
+              title:
+                  widget.teamCode == 'ALL'
+                      ? 'KBO 전체게시판'
+                      : kboTeamLabelOf(widget.teamCode),
+              onSearchPressed: () => context.push(AppRoutePaths.search),
+            ),
 
-              SegmentedTabs(controller: _tabController, items: _tabs),
+            SegmentedTabs(controller: _tabController, items: _tabs),
 
-              // 구분선
-              const Divider(
-                height: 1,
-                thickness: 0.8,
-                color: AppColors.gray400,
+            // 구분선
+            const Divider(height: 1, thickness: 0.8, color: AppColors.gray400),
+            Expanded(
+              child: TabBarView(
+                controller: _tabController,
+                children: List.generate(_tabs.length, (index) {
+                  final tab = _tabs[index];
+                  final isActive = index == _tabController.index;
+                  switch (tab.type) {
+                    case BoardTab.onlywan:
+                      return const Center(child: Text('오직완 페이지'));
+                    case BoardTab.free:
+                      return FreeBoardTab(
+                        teamCode: widget.teamCode,
+                        isActive: isActive,
+                      );
+                    case BoardTab.news:
+                      return const Center(child: Text('오늘의 뉴스'));
+                  }
+                }),
               ),
-              Expanded(
-                child: TabBarView(
-                  controller: _tabController,
-                  children:
-                      _tabs.map((tab) {
-                        switch (tab.type) {
-                          case BoardTab.onlywan:
-                            return const Center(child: Text('오직완 페이지'));
-                          case BoardTab.free:
-                            return FreeBoardTab(teamCode: widget.teamCode);
-                          case BoardTab.news:
-                            return const Center(child: Text('오늘의 뉴스'));
-                        }
-                      }).toList(),
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/feature/community/widgets/shared/segmented_tabs.dart
+++ b/lib/feature/community/widgets/shared/segmented_tabs.dart
@@ -4,6 +4,21 @@ import 'package:inninglog/shared/theme/app_text_styles.dart';
 
 enum BoardTab { onlywan, free, news }
 
+const Map<BoardTab, String> _boardTabPaths = {
+  BoardTab.onlywan: 'onlywan',
+  BoardTab.free: 'free',
+  BoardTab.news: 'news',
+};
+
+String boardTabPath(BoardTab tab) => _boardTabPaths[tab]!;
+
+BoardTab boardTabFromPath(String value) {
+  for (final entry in _boardTabPaths.entries) {
+    if (entry.value == value) return entry.key;
+  }
+  return BoardTab.free;
+}
+
 class CommunityTabItem {
   final BoardTab type;
   final String label;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,18 +27,9 @@ import 'package:inninglog/feature/field/screens/seat_page.dart';
 import 'package:inninglog/feature/community/screens/root_page.dart';
 import 'package:inninglog/feature/mypage/screens/my_page.dart';
 import 'package:inninglog/feature/community/screens/teamboard_page.dart';
-import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
-import 'package:kakao_flutter_sdk_common/kakao_flutter_sdk_common.dart';
-import 'package:amplitude_flutter/amplitude.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:inninglog/feature/community/widgets/shared/segmented_tabs.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'dart:io' show Platform;
-import 'shared/amplitude/analytics.dart';
-import 'package:kakao_flutter_sdk_common/kakao_flutter_sdk_common.dart';
-import 'package:flutter/material.dart';
 import 'package:inninglog/shared/amplitude/AmplitudeFlutter.dart';
-import 'shared/amplitude/AmplitudeFlutter.dart';
 
 const amplitudeKey = String.fromEnvironment('AMPLITUDE_API_KEY');
 
@@ -147,7 +138,7 @@ final GoRouter _router = GoRouter(
       navigatorKey: _shellNavigatorKey,
       observers: [shellRouteObserver],
       builder: (context, state, child) {
-        return MainNavigation(child: child); // ✅ 아래에서 정의할 MainNavigation
+        return MainNavigation(child: child);
       },
       routes: [
         GoRoute(path: '/home', builder: (_, __) => const HomePage()),
@@ -180,10 +171,7 @@ final GoRouter _router = GoRouter(
             ),
           ],
         ),
-        GoRoute(
-          path: '/community',
-          builder: (_, __) => const CommunityRootPage(),
-        ),
+
         GoRoute(path: '/mypage', builder: (_, __) => const MyPage()),
 
         GoRoute(
@@ -197,25 +185,26 @@ final GoRouter _router = GoRouter(
             return SeatDetailPage(seatViewId: seatViewId, imageUrl: imageUrl);
           },
         ),
+        // 커뮤니티
+        GoRoute(
+          path: '/community',
+          builder: (_, __) => const CommunityRootPage(),
+        ),
 
         GoRoute(
           path: AppRoutePaths.board,
           builder: (_, state) {
-            final code = state.pathParameters['code']!; // 팀 코드
-            final tabParam = int.tryParse(
-              state.uri.queryParameters['tab'] ?? '',
-            );
+            final code = state.pathParameters['code']!;
+            final tabParam = state.uri.queryParameters['tab'] ?? 'onlywan';
             return TeamBoardPage(
               teamCode: code,
-              initialTabIndex: tabParam ?? 0, // ✅ 기본 0
+              activeTab: boardTabFromPath(tabParam),
             );
           },
-
           routes: [
             GoRoute(
               path: AppRoutePaths.boardPostWrite,
-              name: 'writing_post',
-              parentNavigatorKey: _rootNavigatorKey, // GNB 없는 화면
+              name: AppRouteNames.writingPost,
               builder: (_, state) {
                 final code = state.pathParameters['code']!;
                 return WritingPostPage(teamCode: code);
@@ -223,8 +212,7 @@ final GoRouter _router = GoRouter(
             ),
             GoRoute(
               path: AppRoutePaths.boardPostDetail,
-              name: 'post_detail',
-              parentNavigatorKey: _rootNavigatorKey, // GNB 없는 화면
+              name: AppRouteNames.postDetail,
               builder: (context, state) {
                 final teamCode = state.pathParameters['code']!;
                 final postId = int.parse(state.pathParameters['postId']!);

--- a/lib/router/app_routes.dart
+++ b/lib/router/app_routes.dart
@@ -10,11 +10,15 @@ final class AppRoutePaths {
   static const boardPostWrite = 'post/new';
   // 게시판 상세 포스트 (중첩 라우터에서 상대 경로)
   static const boardPostDetail = 'posts/:postId';
+  // 팀 게시판 내 글쓰기 (절대 경로)
+  static const boardPostWriteAbs = '/boards/:code/post/new';
+  // 게시판 상세 포스트 (절대 경로)
+  static const boardPostDetailAbs = '/boards/:code/posts/:postId';
   // 커뮤니티 검색
   static const search = '/search';
 
-  static String boardLocation(String code, {int? tab}) {
-    final tabQuery = tab != null ? '?tab=$tab' : '';
+  static String boardLocation(String code, {String? tab}) {
+    final tabQuery = '?tab=${tab ?? 'onlywan'}';
     return '/boards/$code$tabQuery';
   }
 
@@ -23,4 +27,12 @@ final class AppRoutePaths {
   // 절대 경로: 팀 게시판 게시글 상세
   static String boardPostDetailLocation(String code, int postId) =>
       '/boards/$code/posts/$postId';
+}
+
+@immutable
+final class AppRouteNames {
+  const AppRouteNames._();
+
+  static const writingPost = 'writing_post';
+  static const postDetail = 'post_detail';
 }

--- a/lib/router/navigation_policies.dart
+++ b/lib/router/navigation_policies.dart
@@ -1,0 +1,6 @@
+import 'package:inninglog/router/app_routes.dart';
+
+const Set<String> hideBottomNavRouteNames = {
+  AppRouteNames.writingPost,
+  AppRouteNames.postDetail,
+};

--- a/lib/shared/widgets/main_navigation.dart
+++ b/lib/shared/widgets/main_navigation.dart
@@ -1,12 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import '../../feature/home/screens/home_page.dart';
-import '../../feature/diary/screens/diary_page.dart';
-import '../../feature/community/screens/root_page.dart';
-import '../../feature/mypage/screens/my_page.dart';
-import '../../feature/field/screens/seat_page.dart';
-import 'package:inninglog/shared/widgets/main_navigation.dart';
 import 'package:go_router/go_router.dart';
+import 'package:inninglog/router/navigation_policies.dart';
 
 class MainNavigation extends StatelessWidget {
   final Widget child;
@@ -22,76 +17,113 @@ class MainNavigation extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final location =
-        GoRouter.of(context).routeInformationProvider.value.location;
-    final currentIndex = _routes.indexWhere((r) => location.startsWith(r));
+    final router = GoRouter.of(context);
+    // 라우트 변경을 감지해 하단 네비게이션 표시 여부를 즉시 갱신한다.
+    return AnimatedBuilder(
+      animation: router.routerDelegate,
+      builder: (context, _) {
+        // 현재 위치로 활성 탭 인덱스를 계산한다.
+        final location = router.routeInformationProvider.value.location;
+        final currentIndex = _routes.indexWhere((r) => location.startsWith(r));
+        // 현재 활성 라우트의 name을 기준으로 하단 네비 노출 여부를 판단한다.
+        final hideBottomNav = _shouldHideBottomNav(router);
 
-    return Scaffold(
-      body: child,
-      bottomNavigationBar: Container(
-        height: 104,
-        padding: const EdgeInsets.fromLTRB(23, 18, 23, 10),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: const BorderRadius.only(
-            topLeft: Radius.circular(15),
-            topRight: Radius.circular(15),
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.05),
-              offset: const Offset(0, -2),
-              blurRadius: 6.8,
-            ),
-          ],
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            _buildTabItem(
-              context,
-              0,
-              '홈',
-              'assets/icons/Home_black.svg',
-              'assets/icons/Home_gray.svg',
-              currentIndex,
-            ),
-            _buildTabItem(
-              context,
-              1,
-              '직관 일지',
-              'assets/icons/Diary_black.svg',
-              'assets/icons/Diary_gray.svg',
-              currentIndex,
-            ),
-            _buildTabItem(
-              context,
-              2,
-              '구장',
-              'assets/icons/field_black.svg',
-              'assets/icons/field_gray.svg',
-              currentIndex,
-            ),
-            _buildTabItem(
-              context,
-              3,
-              '커뮤니티',
-              'assets/icons/Community_black.svg',
-              'assets/icons/Community_gray.svg',
-              currentIndex,
-            ),
-            _buildTabItem(
-              context,
-              4,
-              '마이페이지',
-              'assets/icons/Mypage_black.svg',
-              'assets/icons/Mypage_gray.svg',
-              currentIndex,
-            ),
-          ],
-        ),
-      ),
+        return Scaffold(
+          body: child,
+          bottomNavigationBar:
+              hideBottomNav
+                  ? null
+                  : Container(
+                    height: 104,
+                    padding: const EdgeInsets.fromLTRB(23, 18, 23, 10),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: const BorderRadius.only(
+                        topLeft: Radius.circular(15),
+                        topRight: Radius.circular(15),
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.05),
+                          offset: const Offset(0, -2),
+                          blurRadius: 6.8,
+                        ),
+                      ],
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        _buildTabItem(
+                          context,
+                          0,
+                          '홈',
+                          'assets/icons/Home_black.svg',
+                          'assets/icons/Home_gray.svg',
+                          currentIndex,
+                        ),
+                        _buildTabItem(
+                          context,
+                          1,
+                          '직관 일지',
+                          'assets/icons/Diary_black.svg',
+                          'assets/icons/Diary_gray.svg',
+                          currentIndex,
+                        ),
+                        _buildTabItem(
+                          context,
+                          2,
+                          '구장',
+                          'assets/icons/field_black.svg',
+                          'assets/icons/field_gray.svg',
+                          currentIndex,
+                        ),
+                        _buildTabItem(
+                          context,
+                          3,
+                          '커뮤니티',
+                          'assets/icons/Community_black.svg',
+                          'assets/icons/Community_gray.svg',
+                          currentIndex,
+                        ),
+                        _buildTabItem(
+                          context,
+                          4,
+                          '마이페이지',
+                          'assets/icons/Mypage_black.svg',
+                          'assets/icons/Mypage_gray.svg',
+                          currentIndex,
+                        ),
+                      ],
+                    ),
+                  ),
+        );
+      },
     );
+  }
+
+  bool _shouldHideBottomNav(GoRouter router) {
+    final config = router.routerDelegate.currentConfiguration;
+    if (config.matches.isEmpty) return false;
+    // 중첩 라우트에서 실제로 활성화된 GoRoute name을 찾는다.
+    final name = _findLastGoRouteName(config.matches);
+    return name != null && hideBottomNavRouteNames.contains(name);
+  }
+
+  String? _findLastGoRouteName(List<RouteMatchBase> matches) {
+    // ShellRoute 등을 통과하므로, 가장 안쪽 GoRoute를 찾기 위해 역순으로 탐색한다.
+    for (final match in matches.reversed) {
+      final route = match.route;
+      if (route is GoRoute) {
+        return route.name;
+      }
+      final nested = match is ShellRouteMatch ? match.matches : null;
+      if (nested != null && nested.isNotEmpty) {
+        // ShellRoute 내부 매칭이 있으면 재귀적으로 더 내려간다.
+        final nestedName = _findLastGoRouteName(nested);
+        if (nestedName != null) return nestedName;
+      }
+    }
+    return null;
   }
 
   Widget _buildTabItem(


### PR DESCRIPTION
## 🎯요약(Summary)
자유게시판 탭 복귀 시 두 케이스에서 목록이 갱신되지 않는 이슈를 해결했습니다. 

- 글 작성 완료 후 목록으로 복귀
- 상세 페이지에서 좋아요/스크랩 후 뒤로가기

## 💻 상세 내용(Describe your changes)

### 문제 원인
- 라우트 계층 분리(Shell vs Root)로 인해 pop 이벤트가 끊긴 것이 핵심 원인
- 자유게시판 탭은 **ShellRoute 내부**, 상세/작성 페이지는 **Root Navigator** 이어서  `RouteAware.didPopNext()`가 Shell에서 호출되지 않음
- 따라서 pop 이벤트가 탭 로직으로 전달되지 않아 결과적으로 refresh 트리거가 사라짐

### 해결 방법
- 자유게시판 상세/작성 라우트를 ShellRoute 내부로 이동해 pop 이벤트가 자연스럽게 전달되도록 구조 정리
- MainNavigation에서 라우트 매치를 재귀적으로 탐색해 마지막 GoRoute name으로 bottom nav 숨김 판단
- bottom nav 숨김 정책을 별도 파일로 분리해 확장성 확보
- FreeBoardTab에서 RouteObserver 기반 refresh 동작과 탭 활성화 시 refresh 유지

## 📌 관련 이슈번호(Related Issue)
- closed: #72 

