### PR TITLE
[Feat] 커뮤니티 게시글 댓글 UI 구현 및 API 연동

### DIFF
--- a/lib/feature/community/model/comment.dart
+++ b/lib/feature/community/model/comment.dart
@@ -1,0 +1,52 @@
+class Comment {
+  final int id;
+  final String nickName;
+  final String? profileUrl;
+  final String content;
+  final int likeCount;
+  final bool likedByMe;
+  final bool writeByMe;
+  final String? createdAt;
+  final List<Comment>? replies;
+
+  const Comment({
+    required this.id,
+    required this.content,
+    required this.nickName,
+    this.profileUrl,
+    this.likeCount = 0,
+    this.likedByMe = false,
+    this.writeByMe = false,
+    this.createdAt,
+    this.replies = const [],
+  });
+}
+
+const List<Comment> dummyComments = [
+  Comment(
+    id: 1,
+    nickName: '메롱',
+    content: '아아',
+    createdAt: '10/24(화) 14:10',
+    likedByMe: false,
+    likeCount: 1,
+    replies: [
+      Comment(
+        id: 1,
+        nickName: '메롱',
+        content: '아아',
+        createdAt: '10/24(화) 14:10',
+        likedByMe: false,
+        likeCount: 1,
+      ),
+    ],
+  ),
+  Comment(
+    id: 1,
+    nickName: '메롱',
+    content: '아아',
+    createdAt: '10/24(화) 14:10',
+    likedByMe: false,
+    likeCount: 1,
+  ),
+];

--- a/lib/feature/community/model/dto/comment_dtos.dart
+++ b/lib/feature/community/model/dto/comment_dtos.dart
@@ -1,0 +1,89 @@
+import 'package:inninglog/feature/community/model/comment.dart';
+
+class CommentMemberShortResDto {
+  final String nickName;
+  final String? profileUrl;
+
+  const CommentMemberShortResDto({
+    required this.nickName,
+    this.profileUrl,
+  });
+
+  factory CommentMemberShortResDto.fromJson(Map<String, dynamic> json) {
+    return CommentMemberShortResDto(
+      nickName: (json['nickName'] ?? '') as String,
+      profileUrl: json['profile_url'] as String?,
+    );
+  }
+}
+
+class CommentResDto {
+  final int commentId;
+  final CommentMemberShortResDto? member;
+  final bool writedByMe;
+  final String content;
+  final String? commentAt;
+  final int likeCount;
+  final bool likedByMe;
+  final bool isDeleted;
+  final List<CommentResDto> replies;
+
+  const CommentResDto({
+    required this.commentId,
+    required this.member,
+    required this.writedByMe,
+    required this.content,
+    required this.commentAt,
+    required this.likeCount,
+    required this.likedByMe,
+    required this.isDeleted,
+    required this.replies,
+  });
+
+  factory CommentResDto.fromJson(Map<String, dynamic> json) {
+    final replies =
+        (json['replies'] as List<dynamic>? ?? const [])
+            .whereType<Map<String, dynamic>>()
+            .map(CommentResDto.fromJson)
+            .toList();
+    return CommentResDto(
+      commentId: (json['commentId'] ?? 0) as int,
+      member:
+          json['memberShortResDto'] is Map<String, dynamic>
+              ? CommentMemberShortResDto.fromJson(
+                json['memberShortResDto'] as Map<String, dynamic>,
+              )
+              : null,
+      writedByMe: json['writedByMe'] == true,
+      content: (json['content'] ?? '') as String,
+      commentAt: json['commentAt'] as String?,
+      likeCount: (json['likeCount'] ?? 0) as int,
+      likedByMe: json['likedByMe'] == true,
+      isDeleted: json['isDeleted'] == true,
+      replies: replies,
+    );
+  }
+
+  Comment toDomain() {
+    return Comment(
+      id: commentId,
+      nickName: member?.nickName ?? '',
+      profileUrl: member?.profileUrl,
+      content: content,
+      likeCount: likeCount,
+      likedByMe: likedByMe,
+      createdAt: commentAt,
+    );
+  }
+}
+
+class CreateCommentRequest {
+  final int? rootCommentId;
+  final String content;
+
+  const CreateCommentRequest({required this.content, this.rootCommentId});
+
+  Map<String, dynamic> toJson() {
+    return {'rootCommentId': rootCommentId, 'content': content};
+  }
+}

--- a/lib/feature/community/repositories/post_repository.dart
+++ b/lib/feature/community/repositories/post_repository.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:inninglog/feature/community/model/community_post.dart';
+import 'package:inninglog/feature/community/model/dto/comment_dtos.dart';
 import 'package:inninglog/feature/community/model/dto/post_dtos.dart';
 import '../../../shared/network/api_envelope.dart';
 import '../model/dto/create_post_dtos.dart';
@@ -124,6 +125,40 @@ class CommunityPostRepository {
     }
 
     return CommunityPostItem.fromJson(json);
+  }
+
+  /// 게시글 댓글 조회
+  Future<List<CommentResDto>> getPostComments({required int postId}) async {
+    final res = await _dio.get('/community/posts/$postId/comments');
+    final json = res.data;
+    if (json is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected comment list response');
+    }
+    final envelope = ApiEnvelope.fromJson(json);
+    final data = envelope.data;
+    final body = data is Map<String, dynamic> ? data : json;
+    final comments =
+        (body['comments'] as List<dynamic>? ?? const [])
+            .whereType<Map<String, dynamic>>()
+            .map(CommentResDto.fromJson)
+            .toList();
+    return comments;
+  }
+
+  /// 게시글 댓글 생성
+  Future<ApiEnvelope> createPostComment({
+    required int postId,
+    required CreateCommentRequest request,
+  }) async {
+    final res = await _dio.post(
+      '/community/posts/$postId/comments',
+      data: request.toJson(),
+    );
+    final json = res.data;
+    if (json is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected create comment response');
+    }
+    return ApiEnvelope.fromJson(json);
   }
 
   /// 게시글 좋아요

--- a/lib/feature/community/screens/post_detail_page.dart
+++ b/lib/feature/community/screens/post_detail_page.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:inninglog/app_scope.dart';
 import 'package:inninglog/feature/community/data/team_catalog.dart';
 import 'package:inninglog/feature/community/model/comment.dart';
+import 'package:inninglog/feature/community/viewmodel/post_comment_view_model.dart';
 import 'package:inninglog/feature/community/viewmodel/post_detail_view_model.dart';
+import 'package:inninglog/feature/community/repositories/post_repository.dart';
 import 'package:inninglog/feature/community/widgets/comment/comment_input_bar.dart';
 import 'package:inninglog/feature/community/widgets/comment/comment_item.dart';
 import 'package:inninglog/feature/community/widgets/comment/empty_comment.dart';
@@ -28,43 +30,41 @@ class PostDetailPage extends StatefulWidget {
 
 class _PostDetailPageState extends State<PostDetailPage> {
   late final PostDetailViewModel _vm;
-
-  final Map<int, List<Comment>> _replies = {};
-
-  int? _activeReplyIndex;
-  final _replyCtrl = TextEditingController();
-
-  final _commentCtrl = TextEditingController();
-
-  final List<Comment> comments = List<Comment>.of(dummyComments);
+  late final CommunityPostRepository _repo;
 
   @override
   void initState() {
     super.initState();
-    final repo = context.read<AppScope>().communityPostRepository;
-    _vm = PostDetailViewModel(repo: repo, postId: widget.postId)..fetch();
+    _repo = context.read<AppScope>().communityPostRepository;
+    _vm = PostDetailViewModel(repo: _repo, postId: widget.postId)..fetch();
   }
 
   @override
   void dispose() {
     _vm.dispose();
-    _commentCtrl.dispose();
-    _replyCtrl.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<PostDetailViewModel>.value(
-      value: _vm,
-      child: Consumer<PostDetailViewModel>(
-        builder: (context, vm, _) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<PostDetailViewModel>.value(value: _vm),
+        ChangeNotifierProvider<PostCommentViewModel>(
+          create:
+              (_) =>
+                  PostCommentViewModel(postId: widget.postId, repo: _repo)
+                    ..fetchComments(),
+        ),
+      ],
+      child: Consumer2<PostDetailViewModel, PostCommentViewModel>(
+        builder: (context, vm, commentVm, _) {
           final post = vm.post;
           final teamCode = post?.teamCode ?? widget.teamCode;
           final teamLabel =
               teamCode == 'ALL' ? 'KBO 전체게시판' : kboTeamLabelOf(teamCode);
           final commentCount =
-              vm.commentCount > 0 ? vm.commentCount : comments.length;
+              vm.commentCount > 0 ? vm.commentCount : commentVm.comments.length;
 
           return Scaffold(
             backgroundColor: AppColors.primary50,
@@ -75,18 +75,18 @@ class _PostDetailPageState extends State<PostDetailPage> {
                 // TODO: 신고/삭제/공유 bottom sheet 등
               },
             ),
-            bottomNavigationBar:
-                (_activeReplyIndex == null)
-                    ? CommentInputBar(
-                      controller: _commentCtrl,
-                      onPressed: _submitComment,
-                    )
-                    : CommentInputBar(
-                      controller: _replyCtrl,
-                      isReplyMode: true,
-                      replyNickname: _activeReplyNickname,
-                      onPressed: _submitReply,
-                    ),
+            bottomNavigationBar: CommentInputBar(
+              controller:
+                  commentVm.isReplyMode
+                      ? commentVm.replyController
+                      : commentVm.commentController,
+              isReplyMode: commentVm.isReplyMode,
+              replyNickname: commentVm.activeReplyNickname,
+              onPressed:
+                  commentVm.isReplyMode
+                      ? commentVm.submitReply
+                      : commentVm.submitComment,
+            ),
             body: ListView(
               children: [
                 PostSection(
@@ -108,11 +108,12 @@ class _PostDetailPageState extends State<PostDetailPage> {
                   commentCount: commentCount,
                 ),
                 const Divider(height: 8, color: AppColors.gray200),
-
-                if (comments.isEmpty)
+                if (commentVm.comments.isEmpty)
                   const EmptyComment()
                 else
-                  ...comments.map(_commentItem),
+                  ...commentVm.comments.map(
+                    (comment) => _commentItem(comment, commentVm),
+                  ),
                 const SizedBox(height: 6),
               ],
             ),
@@ -122,109 +123,20 @@ class _PostDetailPageState extends State<PostDetailPage> {
     );
   }
 
-  String? get _activeReplyNickname {
-    final index = _activeReplyIndex;
-    if (index == null || index < 0 || index >= comments.length) return null;
-    return comments[index].nickName;
-  }
-
-  void _submitComment() {
-    final text = _commentCtrl.text.trim();
-    if (text.isEmpty) return;
-    setState(() {
-      comments.add(
-        Comment(
-          id: DateTime.now().millisecondsSinceEpoch,
-          nickName: '닉네임',
-          content: text,
-          createdAt: '방금',
-          likedByMe: false,
-          likeCount: 0,
-        ),
-      );
-      _commentCtrl.clear();
-    });
-  }
-
-  void _submitReply() {
-    final index = _activeReplyIndex;
-    if (index == null || index < 0 || index >= comments.length) return;
-    final text = _replyCtrl.text.trim();
-    if (text.isEmpty) return;
-    setState(() {
-      final cur = List<Comment>.from(_replies[index] ?? const []);
-      cur.add(
-        Comment(
-          id: DateTime.now().millisecondsSinceEpoch,
-          nickName: '나나ㅏ나',
-          content: text.trim(),
-          createdAt: '방금',
-          likeCount: 0,
-          likedByMe: false,
-        ),
-      );
-
-      _replies[index] = cur;
-      _activeReplyIndex = null;
-      _replyCtrl.clear();
-    });
-  }
-
-  void _toggleCommentLike(int index) {
-    final current = comments[index];
-    final liked = !current.likedByMe;
-    final likeCount = liked ? current.likeCount + 1 : current.likeCount - 1;
-    comments[index] = Comment(
-      id: current.id,
-      nickName: current.nickName,
-      content: current.content,
-      createdAt: current.createdAt,
-      profileUrl: current.profileUrl,
-      likeCount: likeCount,
-      likedByMe: liked,
-    );
-  }
-
-  void _toggleReplyLike(int index, Comment reply) {
-    final replies = List<Comment>.from(_replies[index] ?? const []);
-    final replyIndex = replies.indexOf(reply);
-    if (replyIndex == -1) return;
-
-    final current = replies[replyIndex];
-    final liked = !current.likedByMe;
-    final likeCount = liked ? current.likeCount + 1 : current.likeCount - 1;
-    replies[replyIndex] = Comment(
-      id: current.id,
-      nickName: current.nickName,
-      content: current.content,
-      createdAt: current.createdAt,
-      profileUrl: current.profileUrl,
-      likeCount: likeCount,
-      likedByMe: liked,
-    );
-
-    _replies[index] = replies;
-  }
-
-  Widget _commentItem(Comment c) {
-    final idx = comments.indexOf(c);
-    final bool isReplyingThis = _activeReplyIndex == idx;
-    final List<Comment> replies = _replies[idx] ?? const <Comment>[];
-
+  Widget _commentItem(Comment comment, PostCommentViewModel vm) {
+    final idx = vm.comments.indexOf(comment);
+    final bool isReplyingThis = vm.activeReplyIndex == idx;
+    final List<Comment> replies = vm.repliesFor(idx);
     return CommentItem(
-      comment: c,
+      comment: comment,
       isReplying: isReplyingThis,
       onTapReply: () {
-        setState(() {
-          _activeReplyIndex = idx;
-          _replyCtrl.clear();
-        });
+        vm.startReply(idx);
       },
-      onToggleLike: () => setState(() => _toggleCommentLike(idx)),
+      onToggleLike: () => vm.toggleCommentLike(idx),
       onTapMore: () {},
       replies: replies,
-      onToggleReplyLike:
-          (reply) => setState(() => _toggleReplyLike(idx, reply)),
+      onToggleReplyLike: (reply) => vm.toggleReplyLike(idx, reply),
       onTapReplyMore: (_) {},
     );
   }

--- a/lib/feature/community/screens/post_detail_page.dart
+++ b/lib/feature/community/screens/post_detail_page.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:inninglog/app_scope.dart';
 import 'package:inninglog/feature/community/data/team_catalog.dart';
-import 'package:inninglog/feature/community/model/comment.dart';
 import 'package:inninglog/feature/community/viewmodel/post_comment_view_model.dart';
 import 'package:inninglog/feature/community/viewmodel/post_detail_view_model.dart';
 import 'package:inninglog/feature/community/repositories/post_repository.dart';
 import 'package:inninglog/feature/community/widgets/comment/comment_input_bar.dart';
-import 'package:inninglog/feature/community/widgets/comment/comment_item.dart';
-import 'package:inninglog/feature/community/widgets/comment/empty_comment.dart';
+import 'package:inninglog/feature/community/widgets/comment/comment_list.dart';
 import 'package:inninglog/feature/community/widgets/post_detail/post_action_bar.dart';
 import 'package:inninglog/feature/community/widgets/post_detail/post_detail_app_bar.dart';
 import 'package:inninglog/feature/community/widgets/post_detail/post_header_section.dart';
@@ -28,13 +26,27 @@ class PostDetailPage extends StatefulWidget {
   State<PostDetailPage> createState() => _PostDetailPageState();
 }
 
-class _PostDetailPageState extends State<PostDetailPage> {
+class _PostDetailPageState extends State<PostDetailPage>
+    with WidgetsBindingObserver {
   late final PostDetailViewModel _vm;
   late final CommunityPostRepository _repo;
+  final ScrollController _scrollController = ScrollController();
+  double _lastKeyboardInset = 0;
+  double _keyboardInset = 0;
+
+  @override
+  void didChangeMetrics() {
+    final view = WidgetsBinding.instance.platformDispatcher.views.first;
+    final nextInset = view.viewInsets.bottom / view.devicePixelRatio;
+    if (nextInset == _keyboardInset) return;
+    debugPrint('[PostDetail] didChangeMetrics inset=$nextInset');
+    setState(() => _keyboardInset = nextInset);
+  }
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _repo = context.read<AppScope>().communityPostRepository;
     _vm = PostDetailViewModel(repo: _repo, postId: widget.postId)..fetch();
   }
@@ -42,6 +54,8 @@ class _PostDetailPageState extends State<PostDetailPage> {
   @override
   void dispose() {
     _vm.dispose();
+    _scrollController.dispose();
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 
@@ -68,6 +82,7 @@ class _PostDetailPageState extends State<PostDetailPage> {
 
           return Scaffold(
             backgroundColor: AppColors.primary50,
+            resizeToAvoidBottomInset: true,
             appBar: PostDetailAppBar(
               teamLabel: teamLabel,
               onBack: () => Navigator.pop(context),
@@ -80,6 +95,8 @@ class _PostDetailPageState extends State<PostDetailPage> {
                   commentVm.isReplyMode
                       ? commentVm.replyController
                       : commentVm.commentController,
+              focusNode:
+                  commentVm.isReplyMode ? commentVm.replyFocusNode : null,
               isReplyMode: commentVm.isReplyMode,
               replyNickname: commentVm.activeReplyNickname,
               onPressed:
@@ -87,57 +104,59 @@ class _PostDetailPageState extends State<PostDetailPage> {
                       ? commentVm.submitReply
                       : commentVm.submitComment,
             ),
-            body: ListView(
-              children: [
-                PostSection(
-                  content: post?.content ?? '',
-                  createAt: post?.createdAt ?? '',
-                  nickName: post?.nickName ?? '',
-                  title: post?.title ?? '',
-                  imageUrls:
-                      post?.images.map((e) => e.url).toList() ?? const [],
-                  profileUrl: post?.profileUrl,
-                ),
-                PostActionBar(
-                  likeActive: vm.likedByMe,
-                  likeCount: vm.likeCount,
-                  onTapLike: vm.toggleLike,
-                  scrapActive: vm.scrapedByMe,
-                  scrapCount: vm.scrapCount,
-                  onTapScrap: vm.toggleScrap,
-                  commentCount: commentCount,
-                ),
-                const Divider(height: 8, color: AppColors.gray200),
-                if (commentVm.comments.isEmpty)
-                  const EmptyComment()
-                else
-                  ...commentVm.comments.map(
-                    (comment) => _commentItem(comment, commentVm),
+            body: SafeArea(
+              bottom: false,
+              child: Column(
+                children: [
+                  Expanded(
+                    child: ListView(
+                      controller: _scrollController,
+                      padding: EdgeInsets.zero,
+                      keyboardDismissBehavior:
+                          ScrollViewKeyboardDismissBehavior.onDrag,
+                      children: [
+                        PostSection(
+                          content: post?.content ?? '',
+                          createAt: post?.createdAt ?? '',
+                          nickName: post?.nickName ?? '',
+                          title: post?.title ?? '',
+                          imageUrls:
+                              post?.images.map((e) => e.url).toList() ??
+                              const [],
+                          profileUrl: post?.profileUrl,
+                        ),
+                        PostActionBar(
+                          likeActive: vm.likedByMe,
+                          likeCount: vm.likeCount,
+                          onTapLike: vm.toggleLike,
+                          scrapActive: vm.scrapedByMe,
+                          scrapCount: vm.scrapCount,
+                          onTapScrap: vm.toggleScrap,
+                          commentCount: commentCount,
+                        ),
+                        Container(height: 8, color: AppColors.gray200),
+                        CommentList(
+                          comments: commentVm.comments,
+                          activeReplyIndex: commentVm.activeReplyIndex,
+                          repliesFor: commentVm.repliesFor,
+                          onTapReply: commentVm.startReply,
+                          onToggleLike: commentVm.toggleCommentLike,
+                          onToggleReplyLike:
+                              (reply, index) =>
+                                  commentVm.toggleReplyLike(index, reply),
+                          onTapMore: (_) {},
+                          onTapReplyMore: (_) {},
+                        ),
+                        const SizedBox(height: 6),
+                      ],
+                    ),
                   ),
-                const SizedBox(height: 6),
-              ],
+                ],
+              ),
             ),
           );
         },
       ),
-    );
-  }
-
-  Widget _commentItem(Comment comment, PostCommentViewModel vm) {
-    final idx = vm.comments.indexOf(comment);
-    final bool isReplyingThis = vm.activeReplyIndex == idx;
-    final List<Comment> replies = vm.repliesFor(idx);
-    return CommentItem(
-      comment: comment,
-      isReplying: isReplyingThis,
-      onTapReply: () {
-        vm.startReply(idx);
-      },
-      onToggleLike: () => vm.toggleCommentLike(idx),
-      onTapMore: () {},
-      replies: replies,
-      onToggleReplyLike: (reply) => vm.toggleReplyLike(idx, reply),
-      onTapReplyMore: (_) {},
     );
   }
 }

--- a/lib/feature/community/screens/post_detail_page.dart
+++ b/lib/feature/community/screens/post_detail_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:inninglog/app_scope.dart';
 import 'package:inninglog/feature/community/data/team_catalog.dart';
+import 'package:inninglog/feature/community/model/comment.dart';
 import 'package:inninglog/feature/community/viewmodel/post_detail_view_model.dart';
+import 'package:inninglog/feature/community/widgets/comment/comment_input_bar.dart';
+import 'package:inninglog/feature/community/widgets/comment/comment_item.dart';
+import 'package:inninglog/feature/community/widgets/comment/empty_comment.dart';
 import 'package:inninglog/feature/community/widgets/post_detail/post_action_bar.dart';
 import 'package:inninglog/feature/community/widgets/post_detail/post_detail_app_bar.dart';
 import 'package:inninglog/feature/community/widgets/post_detail/post_header_section.dart';
@@ -26,31 +29,14 @@ class PostDetailPage extends StatefulWidget {
 class _PostDetailPageState extends State<PostDetailPage> {
   late final PostDetailViewModel _vm;
 
-  // ▼ 대댓글 상태 저장 (기존 코드 보존)
-  final Map<int, List<_Reply>> _replies = {}; // 댓글 index -> 대댓글 목록
-  final Set<int> _replying = {}; // 대댓글 입력창 열려있는 댓글 index
+  final Map<int, List<Comment>> _replies = {};
 
   int? _activeReplyIndex;
   final _replyCtrl = TextEditingController();
 
   final _commentCtrl = TextEditingController();
 
-  final List<_Comment> comments = [
-    _Comment(
-      nickname: '메롱',
-      body: '아아',
-      time: '10/24(화) 14:10',
-      liked: false,
-      likes: 1,
-    ),
-    _Comment(
-      nickname: '박해민가면안되ㅡㄴㄴ데',
-      body: '트중박이라고',
-      time: '10/24(화) 14:13',
-      liked: true,
-      likes: 3,
-    ),
-  ];
+  final List<Comment> comments = List<Comment>.of(dummyComments);
 
   @override
   void initState() {
@@ -89,59 +75,18 @@ class _PostDetailPageState extends State<PostDetailPage> {
                 // TODO: 신고/삭제/공유 bottom sheet 등
               },
             ),
-            // 하단 입력바 (디자인 유지)
             bottomNavigationBar:
                 (_activeReplyIndex == null)
-                    // 기본 댓글 입력창
-                    ? _CommentInputBar(
+                    ? CommentInputBar(
                       controller: _commentCtrl,
-                      onPressed: () {
-                        final text = _commentCtrl.text.trim();
-                        if (text.isEmpty) return;
-                        setState(() {
-                          comments.add(
-                            _Comment(
-                              nickname: '닉네임',
-                              body: text,
-                              time: '방금',
-                              liked: false,
-                              likes: 0,
-                            ),
-                          );
-                          _commentCtrl.clear();
-                        });
-                      },
+                      onPressed: _submitComment,
                     )
-                    // ✅ 대댓글 모드일 때
-                    : _ReplyBottomBar(
-                      nickname: comments[_activeReplyIndex!].nickname,
+                    : CommentInputBar(
                       controller: _replyCtrl,
-                      onCancel: () => setState(() => _activeReplyIndex = null),
-                      onSubmit: () {
-                        final text = _replyCtrl.text.trim();
-                        if (text.isEmpty) return;
-                        final i = _activeReplyIndex!;
-                        setState(() {
-                          final cur = List<_Reply>.from(
-                            _replies[i] ?? const [],
-                          );
-                          cur.add(
-                            _Reply(
-                              nickname: '나나ㅏ나',
-                              body: text.trim(),
-                              time: '방금',
-                              likes: 0,
-                              liked: false,
-                            ),
-                          );
-
-                          _replies[i] = cur;
-                          _activeReplyIndex = null;
-                          _replyCtrl.clear();
-                        });
-                      },
+                      isReplyMode: true,
+                      replyNickname: _activeReplyNickname,
+                      onPressed: _submitReply,
                     ),
-
             body: ListView(
               children: [
                 PostSection(
@@ -164,9 +109,8 @@ class _PostDetailPageState extends State<PostDetailPage> {
                 ),
                 const Divider(height: 8, color: AppColors.gray200),
 
-                // 댓글은 고정 노출(토글 X)
                 if (comments.isEmpty)
-                  _EmptyComment()
+                  const EmptyComment()
                 else
                   ...comments.map(_commentItem),
                 const SizedBox(height: 6),
@@ -178,598 +122,110 @@ class _PostDetailPageState extends State<PostDetailPage> {
     );
   }
 
-  Widget _commentItem(_Comment c) {
-    // ▼ 리스트 밖에서 사전 계산 (컴파일 에러 원인 제거)
+  String? get _activeReplyNickname {
+    final index = _activeReplyIndex;
+    if (index == null || index < 0 || index >= comments.length) return null;
+    return comments[index].nickName;
+  }
+
+  void _submitComment() {
+    final text = _commentCtrl.text.trim();
+    if (text.isEmpty) return;
+    setState(() {
+      comments.add(
+        Comment(
+          id: DateTime.now().millisecondsSinceEpoch,
+          nickName: '닉네임',
+          content: text,
+          createdAt: '방금',
+          likedByMe: false,
+          likeCount: 0,
+        ),
+      );
+      _commentCtrl.clear();
+    });
+  }
+
+  void _submitReply() {
+    final index = _activeReplyIndex;
+    if (index == null || index < 0 || index >= comments.length) return;
+    final text = _replyCtrl.text.trim();
+    if (text.isEmpty) return;
+    setState(() {
+      final cur = List<Comment>.from(_replies[index] ?? const []);
+      cur.add(
+        Comment(
+          id: DateTime.now().millisecondsSinceEpoch,
+          nickName: '나나ㅏ나',
+          content: text.trim(),
+          createdAt: '방금',
+          likeCount: 0,
+          likedByMe: false,
+        ),
+      );
+
+      _replies[index] = cur;
+      _activeReplyIndex = null;
+      _replyCtrl.clear();
+    });
+  }
+
+  void _toggleCommentLike(int index) {
+    final current = comments[index];
+    final liked = !current.likedByMe;
+    final likeCount = liked ? current.likeCount + 1 : current.likeCount - 1;
+    comments[index] = Comment(
+      id: current.id,
+      nickName: current.nickName,
+      content: current.content,
+      createdAt: current.createdAt,
+      profileUrl: current.profileUrl,
+      likeCount: likeCount,
+      likedByMe: liked,
+    );
+  }
+
+  void _toggleReplyLike(int index, Comment reply) {
+    final replies = List<Comment>.from(_replies[index] ?? const []);
+    final replyIndex = replies.indexOf(reply);
+    if (replyIndex == -1) return;
+
+    final current = replies[replyIndex];
+    final liked = !current.likedByMe;
+    final likeCount = liked ? current.likeCount + 1 : current.likeCount - 1;
+    replies[replyIndex] = Comment(
+      id: current.id,
+      nickName: current.nickName,
+      content: current.content,
+      createdAt: current.createdAt,
+      profileUrl: current.profileUrl,
+      likeCount: likeCount,
+      likedByMe: liked,
+    );
+
+    _replies[index] = replies;
+  }
+
+  Widget _commentItem(Comment c) {
     final idx = comments.indexOf(c);
     final bool isReplyingThis = _activeReplyIndex == idx;
-    final List<_Reply> replies = _replies[idx] ?? const <_Reply>[];
+    final List<Comment> replies = _replies[idx] ?? const <Comment>[];
 
-    return Container(
-      decoration: BoxDecoration(
-        color: isReplyingThis ? AppColors.primary100 : Colors.white,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 0),
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              const _AvatarSmall(),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  c.nickname,
-                  style: const TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.gray800,
-                  ),
-                ),
-              ),
-              // 옆 댓글하트박스
-              Container(
-                height: 24,
-                padding: const EdgeInsets.symmetric(horizontal: 0),
-                decoration: BoxDecoration(
-                  color: AppColors.gray100, // 연한 회색 배경
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    // 댓글 아이콘 (항상 회색) → 대댓글 입력 열기
-                    _IconButtonBox(
-                      onTap: () {
-                        setState(() {
-                          _activeReplyIndex = idx;
-                          _replyCtrl.clear();
-                        });
-                      },
-                      child: SvgPicture.asset(
-                        'assets/icons/board_comment.svg',
-                        width: 14,
-                        height: 12,
-                        colorFilter: const ColorFilter.mode(
-                          AppColors.gray400,
-                          BlendMode.srcIn,
-                        ),
-                      ),
-                    ),
-
-                    _VBar(),
-
-                    // 하트 (토글 색상)
-                    _IconButtonBox(
-                      onTap: () {
-                        setState(() {
-                          c.liked = !c.liked;
-                          c.liked ? c.likes++ : c.likes--;
-                        });
-                      },
-                      child: SvgPicture.asset(
-                        'assets/icons/board_heart.svg',
-                        width: 14,
-                        height: 12,
-                        colorFilter: ColorFilter.mode(
-                          c.liked ? AppColors.primary700 : AppColors.gray400,
-                          BlendMode.srcIn,
-                        ),
-                      ),
-                    ),
-
-                    _VBar(),
-
-                    // 더보기 (세로 점 3개)
-                    _IconButtonBox(
-                      onTap: () {}, // 신고/삭제 등 메뉴 오픈
-                      child: const Icon(
-                        Icons.more_vert,
-                        size: 14,
-                        color: AppColors.gray400,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-
-          const SizedBox(height: 8),
-
-          // 원댓글 본문 (작성중이면 하이라이트)
-          Container(
-            color: isReplyingThis ? AppColors.primary100 : Colors.transparent,
-            child: Text(
-              c.body,
-              style: const TextStyle(
-                fontSize: 14,
-                color: AppColors.gray800,
-                fontWeight: FontWeight.w400,
-              ),
-            ),
-          ),
-
-          const SizedBox(height: 8),
-
-          Text(
-            c.time,
-            style: const TextStyle(
-              fontSize: 10,
-              color: AppColors.gray600,
-              fontWeight: FontWeight.w500,
-            ),
-          ),
-
-          // ▼ 대댓글 리스트
-          if (replies.isNotEmpty) ...[
-            const SizedBox(height: 12),
-            Column(
-              children:
-                  replies.map((r) {
-                    return Padding(
-                      padding: const EdgeInsets.only(
-                        left: 0,
-                        bottom: 0,
-                      ), // 들여쓰기
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          // ㄴ 모양 가이드
-                          Container(
-                            width: 10,
-                            height: 18,
-                            margin: const EdgeInsets.only(
-                              right: 0,
-                              top: 4,
-                              left: 0,
-                            ),
-                            child: SvgPicture.asset(
-                              'assets/icons/board_reply.svg',
-                              width: 11,
-                              height: 15,
-                              colorFilter: const ColorFilter.mode(
-                                AppColors.gray300,
-                                BlendMode.srcIn,
-                              ),
-                            ),
-                          ),
-
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  r.nickname,
-                                  style: const TextStyle(
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.w600,
-                                    color: AppColors.gray800,
-                                  ),
-                                ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  r.body,
-                                  style: const TextStyle(
-                                    fontSize: 14,
-                                    color: AppColors.gray900,
-                                    height: 1.5,
-                                  ),
-                                ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  r.time,
-                                  style: const TextStyle(
-                                    fontSize: 12,
-                                    color: AppColors.gray500,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          Container(
-                            height: 24,
-                            padding: const EdgeInsets.symmetric(horizontal: 0),
-                            decoration: BoxDecoration(
-                              color: AppColors.gray100, // 연한 회색 배경
-                              borderRadius: BorderRadius.circular(4),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                // 하트 (토글 색상)
-                                _IconButtonBox(
-                                  onTap: () {
-                                    setState(() {
-                                      c.liked = !c.liked;
-                                      c.liked ? c.likes++ : c.likes--;
-                                    });
-                                  },
-                                  child: SvgPicture.asset(
-                                    'assets/icons/board_heart.svg',
-                                    width: 14,
-                                    height: 12,
-                                    colorFilter: ColorFilter.mode(
-                                      c.liked
-                                          ? AppColors.primary700
-                                          : AppColors.gray400,
-                                      BlendMode.srcIn,
-                                    ),
-                                  ),
-                                ),
-
-                                _VBar(),
-
-                                // 더보기 (세로 점 3개)
-                                _IconButtonBox(
-                                  onTap: () {}, // 신고/삭제 등 메뉴 오픈
-                                  child: const Icon(
-                                    Icons.more_vert,
-                                    size: 14,
-                                    color: AppColors.gray400,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  }).toList(),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-/// ───────────────────────── 위젯들 ─────────────────────────
-
-/// 댓글 없을 때
-class _EmptyComment extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      color: AppColors.primary50,
-      padding: const EdgeInsets.only(top: 120),
-      alignment: Alignment.center,
-      child: Column(
-        children: [
-          SvgPicture.asset(
-            'assets/icons/board_bori.svg',
-            width: 60,
-            height: 60,
-          ),
-          const SizedBox(height: 24),
-          const Text(
-            '첫 번째 댓글을 남겨주세요!',
-            style: TextStyle(
-              fontSize: 16,
-              color: AppColors.gray600,
-              fontWeight: FontWeight.w400,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// 댓글 입력바
-class _CommentInputBar extends StatelessWidget {
-  final TextEditingController controller;
-  final VoidCallback onPressed;
-  const _CommentInputBar({required this.controller, required this.onPressed});
-
-  @override
-  Widget build(BuildContext context) {
-    final hasText = controller.text.isNotEmpty;
-    return SafeArea(
-      top: false,
-      child: Container(
-        color: Colors.white,
-        padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
-        child: Row(
-          children: [
-            Expanded(
-              child: Container(
-                height: 45,
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-                decoration: BoxDecoration(
-                  color: const Color(0xFFF8F8F8),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                alignment: Alignment.center,
-                child: TextField(
-                  cursorColor: AppColors.primary700,
-                  controller: controller,
-                  onChanged: (_) => (context as Element).markNeedsBuild(),
-                  style: const TextStyle(
-                    fontSize: 14,
-                    color: AppColors.gray800,
-                    fontWeight: FontWeight.w400,
-                  ),
-                  decoration: InputDecoration(
-                    isDense: true,
-                    border: InputBorder.none,
-                    hintText: '댓글을 입력하세요.',
-                    hintStyle: const TextStyle(
-                      fontSize: 14,
-                      color: AppColors.gray600,
-                      fontWeight: FontWeight.w400,
-                    ),
-                    // ✅ 텍스트필드 내부 오른쪽 버튼
-                    suffixIcon: Padding(
-                      padding: const EdgeInsets.only(right: 8),
-                      child: InkWell(
-                        onTap: onPressed,
-                        borderRadius: BorderRadius.circular(0),
-                        child: Container(
-                          height: 21.58,
-                          width: 32,
-                          decoration: BoxDecoration(
-                            color:
-                                hasText
-                                    ? AppColors.primary700
-                                    : const Color(0xFFC0C0C0),
-                            borderRadius: BorderRadius.circular(5.95),
-                          ),
-                          child: Center(
-                            child: SvgPicture.asset(
-                              'assets/icons/vector_board.svg',
-                              width: 9.39,
-                              height: 14.13,
-                              colorFilter: const ColorFilter.mode(
-                                AppColors.gray50,
-                                BlendMode.srcIn,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    // ✅ suffixIcon이 TextField 안쪽에 잘 맞게 패딩 조절
-                    suffixIconConstraints: const BoxConstraints(
-                      minWidth: 36,
-                      minHeight: 36,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _AvatarSmall extends StatelessWidget {
-  const _AvatarSmall();
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 24,
-      height: 24,
-      decoration: const BoxDecoration(
-        shape: BoxShape.circle,
-        color: Color(0xFFE5E7EB),
-      ),
-    );
-  }
-}
-
-class _Comment {
-  final String nickname;
-  final String body;
-  final String time;
-  int likes;
-  bool liked;
-  _Comment({
-    required this.nickname,
-    required this.body,
-    required this.time,
-    required this.liked,
-    required this.likes,
-  });
-}
-
-class _IconButtonBox extends StatelessWidget {
-  final VoidCallback onTap;
-  final Widget child;
-  const _IconButtonBox({required this.onTap, required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(8),
-      child: SizedBox(width: 36, height: 36, child: Center(child: child)),
-    );
-  }
-}
-
-class _VBar extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 1,
-      height: 16,
-      margin: const EdgeInsets.symmetric(horizontal: 8),
-      color: AppColors.gray400,
-    );
-  }
-}
-
-class _Reply {
-  final String nickname;
-  final String body;
-  final String time;
-  int likes;
-  bool liked;
-
-  _Reply({
-    required this.nickname,
-    required this.body,
-    required this.time,
-    this.likes = 0,
-    this.liked = false,
-  });
-}
-
-class _ElbowPainter extends CustomPainter {
-  final Color color;
-  const _ElbowPainter({required this.color});
-  @override
-  void paint(Canvas canvas, Size size) {
-    final p =
-        Paint()
-          ..color = color
-          ..strokeWidth = 1.0
-          ..style = PaintingStyle.stroke;
-    final path =
-        Path()
-          ..moveTo(size.width - 1, 0)
-          ..lineTo(size.width - 1, size.height - 6)
-          ..lineTo(0, size.height - 6);
-    canvas.drawPath(path, p);
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
-}
-
-/// ✅ 대댓글 입력 모드일 때 사용하는 하단바
-class _ReplyBottomBar extends StatelessWidget {
-  final String nickname;
-  final TextEditingController controller;
-  final VoidCallback onCancel;
-  final VoidCallback onSubmit;
-
-  const _ReplyBottomBar({
-    required this.nickname,
-    required this.controller,
-    required this.onCancel,
-    required this.onSubmit,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final hasText = controller.text.isNotEmpty;
-
-    return SafeArea(
-      top: false,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // 안내줄
-          Container(
-            height: 37,
-            margin: const EdgeInsets.fromLTRB(20, 8, 20, 0),
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            decoration: BoxDecoration(
-              color: Color(0xFFEFEFEF),
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(12),
-                topRight: Radius.circular(12),
-              ),
-            ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    '$nickname님에게 대댓글 남기는 중',
-                    style: const TextStyle(
-                      fontSize: 12,
-                      color: AppColors.gray500,
-                      fontWeight: FontWeight.w500,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          // 기존 입력창 그대로 재사용
-          Container(
-            color: Colors.white,
-            padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Container(
-                    height: 45,
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    decoration: BoxDecoration(
-                      color: const Color(0xFFF8F8F8),
-                      borderRadius: const BorderRadius.only(
-                        bottomLeft: Radius.circular(12),
-                        bottomRight: Radius.circular(12),
-                      ),
-                    ),
-                    alignment: Alignment.center,
-                    child: TextField(
-                      controller: controller,
-                      cursorColor: AppColors.primary700,
-                      onChanged: (_) => (context as Element).markNeedsBuild(),
-                      style: const TextStyle(
-                        fontSize: 14,
-                        color: AppColors.gray800,
-                        fontWeight: FontWeight.w400,
-                      ),
-                      decoration: InputDecoration(
-                        isDense: true,
-                        border: InputBorder.none,
-                        hintText: '댓글을 입력하세요.',
-                        hintStyle: const TextStyle(
-                          fontSize: 14,
-                          color: AppColors.gray600,
-                          fontWeight: FontWeight.w400,
-                        ),
-                        suffixIcon: Padding(
-                          padding: const EdgeInsets.only(right: 8),
-                          child: InkWell(
-                            onTap: onSubmit,
-                            borderRadius: BorderRadius.circular(0),
-                            child: Container(
-                              height: 21.58,
-                              width: 32,
-                              decoration: BoxDecoration(
-                                color:
-                                    hasText
-                                        ? AppColors.primary700
-                                        : const Color(0xFFC0C0C0),
-                                borderRadius: BorderRadius.circular(5.95),
-                              ),
-                              child: Center(
-                                child: SvgPicture.asset(
-                                  'assets/icons/vector_board.svg',
-                                  width: 9.39,
-                                  height: 14.13,
-                                  colorFilter: const ColorFilter.mode(
-                                    AppColors.gray50,
-                                    BlendMode.srcIn,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                        suffixIconConstraints: const BoxConstraints(
-                          minWidth: 36,
-                          minHeight: 36,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
+    return CommentItem(
+      comment: c,
+      isReplying: isReplyingThis,
+      onTapReply: () {
+        setState(() {
+          _activeReplyIndex = idx;
+          _replyCtrl.clear();
+        });
+      },
+      onToggleLike: () => setState(() => _toggleCommentLike(idx)),
+      onTapMore: () {},
+      replies: replies,
+      onToggleReplyLike:
+          (reply) => setState(() => _toggleReplyLike(idx, reply)),
+      onTapReplyMore: (_) {},
     );
   }
 }

--- a/lib/feature/community/screens/post_detail_page.dart
+++ b/lib/feature/community/screens/post_detail_page.dart
@@ -32,16 +32,6 @@ class _PostDetailPageState extends State<PostDetailPage>
   late final CommunityPostRepository _repo;
   final ScrollController _scrollController = ScrollController();
   double _lastKeyboardInset = 0;
-  double _keyboardInset = 0;
-
-  @override
-  void didChangeMetrics() {
-    final view = WidgetsBinding.instance.platformDispatcher.views.first;
-    final nextInset = view.viewInsets.bottom / view.devicePixelRatio;
-    if (nextInset == _keyboardInset) return;
-    debugPrint('[PostDetail] didChangeMetrics inset=$nextInset');
-    setState(() => _keyboardInset = nextInset);
-  }
 
   @override
   void initState() {
@@ -57,6 +47,22 @@ class _PostDetailPageState extends State<PostDetailPage>
     _scrollController.dispose();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    final view = WidgetsBinding.instance.platformDispatcher.views.first;
+    final nextInset = view.viewInsets.bottom / view.devicePixelRatio;
+    if (nextInset == _lastKeyboardInset) return;
+    final delta = nextInset - _lastKeyboardInset;
+    _lastKeyboardInset = nextInset;
+    if (!_scrollController.hasClients) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_scrollController.hasClients) return;
+      final max = _scrollController.position.maxScrollExtent;
+      final nextOffset = (_scrollController.offset + delta).clamp(0.0, max);
+      _scrollController.jumpTo(nextOffset);
+    });
   }
 
   @override
@@ -89,20 +95,6 @@ class _PostDetailPageState extends State<PostDetailPage>
               onTapMore: () {
                 // TODO: 신고/삭제/공유 bottom sheet 등
               },
-            ),
-            bottomNavigationBar: CommentInputBar(
-              controller:
-                  commentVm.isReplyMode
-                      ? commentVm.replyController
-                      : commentVm.commentController,
-              focusNode:
-                  commentVm.isReplyMode ? commentVm.replyFocusNode : null,
-              isReplyMode: commentVm.isReplyMode,
-              replyNickname: commentVm.activeReplyNickname,
-              onPressed:
-                  commentVm.isReplyMode
-                      ? commentVm.submitReply
-                      : commentVm.submitComment,
             ),
             body: SafeArea(
               bottom: false,
@@ -149,6 +141,25 @@ class _PostDetailPageState extends State<PostDetailPage>
                         ),
                         const SizedBox(height: 6),
                       ],
+                    ),
+                  ),
+                  SafeArea(
+                    top: false,
+                    child: CommentInputBar(
+                      controller:
+                          commentVm.isReplyMode
+                              ? commentVm.replyController
+                              : commentVm.commentController,
+                      focusNode:
+                          commentVm.isReplyMode
+                              ? commentVm.replyFocusNode
+                              : commentVm.commentFocusNode,
+                      isReplyMode: commentVm.isReplyMode,
+                      replyNickname: commentVm.activeReplyNickname,
+                      onPressed:
+                          commentVm.isReplyMode
+                              ? commentVm.submitReply
+                              : commentVm.submitComment,
                     ),
                   ),
                 ],

--- a/lib/feature/community/viewmodel/post_comment_view_model.dart
+++ b/lib/feature/community/viewmodel/post_comment_view_model.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/model/comment.dart';
+import 'package:inninglog/feature/community/model/dto/comment_dtos.dart';
+import 'package:inninglog/feature/community/repositories/post_repository.dart';
+
+class PostCommentViewModel extends ChangeNotifier {
+  final int postId;
+  final CommunityPostRepository repo;
+  final TextEditingController commentController = TextEditingController();
+  final TextEditingController replyController = TextEditingController();
+
+  final List<Comment> _comments = [];
+  final Map<int, List<Comment>> _replies = {};
+  int? _activeReplyIndex;
+  bool _isLoading = false;
+
+  PostCommentViewModel({
+    required this.postId,
+    required this.repo,
+    List<Comment>? initialComments,
+  }) {
+    if (initialComments != null) {
+      _comments.addAll(initialComments);
+    }
+  }
+
+  List<Comment> get comments => List.unmodifiable(_comments);
+
+  List<Comment> repliesFor(int index) =>
+      List.unmodifiable(_replies[index] ?? const <Comment>[]);
+
+  int? get activeReplyIndex => _activeReplyIndex;
+
+  bool get isReplyMode => _activeReplyIndex != null;
+
+  bool get isLoading => _isLoading;
+
+  String? get activeReplyNickname {
+    final index = _activeReplyIndex;
+    if (index == null || index < 0 || index >= _comments.length) return null;
+    return _comments[index].nickName;
+  }
+
+  Future<void> fetchComments() async {
+    if (_isLoading) return;
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final commentDtos = await repo.getPostComments(postId: postId);
+      _applyCommentDtos(commentDtos);
+    } catch (e) {
+      debugPrint('[PostComment] fetch error: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void startReply(int index) {
+    if (index < 0 || index >= _comments.length) return;
+    _activeReplyIndex = index;
+    replyController.clear();
+    notifyListeners();
+  }
+
+  Future<void> submitComment() async {
+    final text = commentController.text.trim();
+    if (text.isEmpty) return;
+    try {
+      await repo.createPostComment(
+        postId: postId,
+        request: CreateCommentRequest(content: text, rootCommentId: null),
+      );
+      commentController.clear();
+      await fetchComments();
+    } catch (e) {
+      debugPrint('[PostComment] submit comment error: $e');
+    }
+  }
+
+  Future<void> submitReply() async {
+    final index = _activeReplyIndex;
+    if (index == null || index < 0 || index >= _comments.length) return;
+    final text = replyController.text.trim();
+    if (text.isEmpty) return;
+
+    try {
+      final rootCommentId = _comments[index].id;
+      await repo.createPostComment(
+        postId: postId,
+        request: CreateCommentRequest(
+          content: text,
+          rootCommentId: rootCommentId,
+        ),
+      );
+      _activeReplyIndex = null;
+      replyController.clear();
+      await fetchComments();
+    } catch (e) {
+      debugPrint('[PostComment] submit reply error: $e');
+    }
+  }
+
+  void toggleCommentLike(int index) {
+    if (index < 0 || index >= _comments.length) return;
+    final current = _comments[index];
+    final liked = !current.likedByMe;
+    final likeCount = liked ? current.likeCount + 1 : current.likeCount - 1;
+    _comments[index] = Comment(
+      id: current.id,
+      nickName: current.nickName,
+      content: current.content,
+      createdAt: current.createdAt,
+      profileUrl: current.profileUrl,
+      likeCount: likeCount,
+      likedByMe: liked,
+    );
+    notifyListeners();
+  }
+
+  void toggleReplyLike(int index, Comment reply) {
+    final replies = List<Comment>.from(_replies[index] ?? const []);
+    final replyIndex = replies.indexOf(reply);
+    if (replyIndex == -1) return;
+
+    final current = replies[replyIndex];
+    final liked = !current.likedByMe;
+    final likeCount = liked ? current.likeCount + 1 : current.likeCount - 1;
+    replies[replyIndex] = Comment(
+      id: current.id,
+      nickName: current.nickName,
+      content: current.content,
+      createdAt: current.createdAt,
+      profileUrl: current.profileUrl,
+      likeCount: likeCount,
+      likedByMe: liked,
+    );
+    _replies[index] = replies;
+    notifyListeners();
+  }
+
+  void _applyCommentDtos(List<CommentResDto> dtos) {
+    _comments
+      ..clear()
+      ..addAll(dtos.map((dto) => dto.toDomain()));
+    _replies.clear();
+    for (var i = 0; i < dtos.length; i++) {
+      final replies = dtos[i].replies.map((r) => r.toDomain()).toList();
+      if (replies.isNotEmpty) {
+        _replies[i] = replies;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    commentController.dispose();
+    replyController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/feature/community/viewmodel/post_comment_view_model.dart
+++ b/lib/feature/community/viewmodel/post_comment_view_model.dart
@@ -9,6 +9,7 @@ class PostCommentViewModel extends ChangeNotifier {
   final TextEditingController commentController = TextEditingController();
   final TextEditingController replyController = TextEditingController();
   final FocusNode replyFocusNode = FocusNode();
+  final FocusNode commentFocusNode = FocusNode();
 
   final List<Comment> _comments = [];
   final Map<int, List<Comment>> _replies = {};
@@ -159,6 +160,7 @@ class PostCommentViewModel extends ChangeNotifier {
     commentController.dispose();
     replyController.dispose();
     replyFocusNode.dispose();
+    commentFocusNode.dispose();
     super.dispose();
   }
 }

--- a/lib/feature/community/viewmodel/post_comment_view_model.dart
+++ b/lib/feature/community/viewmodel/post_comment_view_model.dart
@@ -8,6 +8,7 @@ class PostCommentViewModel extends ChangeNotifier {
   final CommunityPostRepository repo;
   final TextEditingController commentController = TextEditingController();
   final TextEditingController replyController = TextEditingController();
+  final FocusNode replyFocusNode = FocusNode();
 
   final List<Comment> _comments = [];
   final Map<int, List<Comment>> _replies = {};
@@ -60,6 +61,7 @@ class PostCommentViewModel extends ChangeNotifier {
     if (index < 0 || index >= _comments.length) return;
     _activeReplyIndex = index;
     replyController.clear();
+    replyFocusNode.requestFocus();
     notifyListeners();
   }
 
@@ -156,6 +158,7 @@ class PostCommentViewModel extends ChangeNotifier {
   void dispose() {
     commentController.dispose();
     replyController.dispose();
+    replyFocusNode.dispose();
     super.dispose();
   }
 }

--- a/lib/feature/community/widgets/comment/comment_input_bar.dart
+++ b/lib/feature/community/widgets/comment/comment_input_bar.dart
@@ -7,6 +7,7 @@ class CommentInputBar extends StatelessWidget {
   final TextEditingController controller;
   final FocusNode? focusNode;
   final VoidCallback onPressed;
+  final ValueChanged<bool>? onFocusChange;
   final bool isReplyMode;
   final String? replyNickname;
 
@@ -17,6 +18,7 @@ class CommentInputBar extends StatelessWidget {
     required this.controller,
     this.focusNode,
     required this.onPressed,
+    this.onFocusChange,
     this.isReplyMode = false,
     this.replyNickname,
     this.maxLines = 4,
@@ -58,25 +60,28 @@ class CommentInputBar extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     Expanded(
-                      child: TextField(
-                        controller: controller,
-                        focusNode: focusNode,
-                        cursorColor: AppColors.primary700,
-                        minLines: 1,
-                        maxLines: maxLines, // ✅ 4줄까지는 높이 증가, 이후는 내부 스크롤
-                        keyboardType: TextInputType.multiline,
-                        textAlignVertical: TextAlignVertical.top,
-                        style: AppTextStyles.bodyBody2Rg.copyWith(
-                          color: AppColors.gray800,
-                        ),
-                        decoration: InputDecoration(
-                          isDense: true,
-                          border: InputBorder.none,
-                          hintText: '댓글로 의견을 남겨보세요.',
-                          hintStyle: AppTextStyles.bodyBody2Rg.copyWith(
-                            color: AppColors.gray600,
+                      child: Focus(
+                        onFocusChange: onFocusChange,
+                        child: TextField(
+                          controller: controller,
+                          focusNode: focusNode,
+                          cursorColor: AppColors.primary700,
+                          minLines: 1,
+                          maxLines: maxLines, // ✅ 4줄까지는 높이 증가, 이후는 내부 스크롤
+                          keyboardType: TextInputType.multiline,
+                          textAlignVertical: TextAlignVertical.top,
+                          style: AppTextStyles.bodyBody2Rg.copyWith(
+                            color: AppColors.gray800,
                           ),
-                          contentPadding: EdgeInsets.zero,
+                          decoration: InputDecoration(
+                            isDense: true,
+                            border: InputBorder.none,
+                            hintText: '댓글로 의견을 남겨보세요.',
+                            hintStyle: AppTextStyles.bodyBody2Rg.copyWith(
+                              color: AppColors.gray600,
+                            ),
+                            contentPadding: EdgeInsets.zero,
+                          ),
                         ),
                       ),
                     ),

--- a/lib/feature/community/widgets/comment/comment_input_bar.dart
+++ b/lib/feature/community/widgets/comment/comment_input_bar.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+class CommentInputBar extends StatelessWidget {
+  final TextEditingController controller;
+  final VoidCallback onPressed;
+  final bool isReplyMode;
+  final String? replyNickname;
+
+  final int maxLines; // 4줄까지 확장
+
+  const CommentInputBar({
+    super.key,
+    required this.controller,
+    required this.onPressed,
+    this.isReplyMode = false,
+    this.replyNickname,
+    this.maxLines = 4,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // ✅ controller 값 변화에 따라 hasText가 자동 갱신되게 (markNeedsBuild 제거)
+    return ValueListenableBuilder<TextEditingValue>(
+      valueListenable: controller,
+      builder: (context, value, _) {
+        final hasText = value.text.trim().isNotEmpty;
+
+        return SafeArea(
+          top: false,
+          child: Container(
+            color: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (isReplyMode)
+                  _ReplyTopBar(nickName: replyNickname ?? ''), //대댓글 인 경우
+                Container(
+                  decoration: BoxDecoration(
+                    color: AppColors.gray100,
+                    borderRadius:
+                        isReplyMode
+                            ? BorderRadius.circular(8)
+                            : BorderRadius.only(
+                              bottomLeft: Radius.circular(8),
+                              bottomRight: Radius.circular(8),
+                            ),
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                  child: Row(
+                    spacing: 8,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: controller,
+                          cursorColor: AppColors.primary700,
+                          minLines: 1,
+                          maxLines: maxLines, // ✅ 4줄까지는 높이 증가, 이후는 내부 스크롤
+                          keyboardType: TextInputType.multiline,
+                          textAlignVertical: TextAlignVertical.top,
+                          style: AppTextStyles.bodyBody2Rg.copyWith(
+                            color: AppColors.gray800,
+                          ),
+                          decoration: InputDecoration(
+                            isDense: true,
+                            border: InputBorder.none,
+                            hintText: '댓글로 의견을 남겨보세요.',
+                            hintStyle: AppTextStyles.bodyBody2Rg.copyWith(
+                              color: AppColors.gray600,
+                            ),
+                            contentPadding: EdgeInsets.zero,
+                          ),
+                        ),
+                      ),
+                      _SendButton(
+                        enabled: hasText,
+                        onTap: hasText ? onPressed : null,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SendButton extends StatelessWidget {
+  final bool enabled;
+
+  final VoidCallback? onTap;
+
+  const _SendButton({required this.enabled, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: enabled ? AppColors.primary700 : const Color(0xFFC0C0C0),
+      borderRadius: BorderRadius.circular(8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: SizedBox(
+          width: 32,
+          height: 22,
+          child: Center(
+            child: SvgPicture.asset(
+              'assets/icons/vector_board.svg',
+              width: 9.39,
+              height: 14.13,
+              colorFilter: const ColorFilter.mode(
+                AppColors.gray50,
+                BlendMode.srcIn,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReplyTopBar extends StatelessWidget {
+  final String nickName;
+  const _ReplyTopBar({required this.nickName});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 37,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      decoration: BoxDecoration(
+        color: AppColors.gray200,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(12),
+          topRight: Radius.circular(12),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              '$nickName님에게 대댓글 남기는 중',
+              style: AppTextStyles.headHead8M.copyWith(
+                color: AppColors.gray500,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/comment/comment_input_bar.dart
+++ b/lib/feature/community/widgets/comment/comment_input_bar.dart
@@ -5,6 +5,7 @@ import 'package:inninglog/shared/theme/app_text_styles.dart';
 
 class CommentInputBar extends StatelessWidget {
   final TextEditingController controller;
+  final FocusNode? focusNode;
   final VoidCallback onPressed;
   final bool isReplyMode;
   final String? replyNickname;
@@ -14,6 +15,7 @@ class CommentInputBar extends StatelessWidget {
   const CommentInputBar({
     super.key,
     required this.controller,
+    this.focusNode,
     required this.onPressed,
     this.isReplyMode = false,
     this.replyNickname,
@@ -28,66 +30,70 @@ class CommentInputBar extends StatelessWidget {
       builder: (context, value, _) {
         final hasText = value.text.trim().isNotEmpty;
 
-        return SafeArea(
-          top: false,
-          child: Container(
-            color: Colors.white,
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (isReplyMode)
-                  _ReplyTopBar(nickName: replyNickname ?? ''), //대댓글 인 경우
-                Container(
-                  decoration: BoxDecoration(
-                    color: AppColors.gray100,
-                    borderRadius:
-                        isReplyMode
-                            ? BorderRadius.circular(8)
-                            : BorderRadius.only(
-                              bottomLeft: Radius.circular(8),
-                              bottomRight: Radius.circular(8),
-                            ),
-                  ),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 8,
-                  ),
-                  child: Row(
-                    spacing: 8,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      Expanded(
-                        child: TextField(
-                          controller: controller,
-                          cursorColor: AppColors.primary700,
-                          minLines: 1,
-                          maxLines: maxLines, // ✅ 4줄까지는 높이 증가, 이후는 내부 스크롤
-                          keyboardType: TextInputType.multiline,
-                          textAlignVertical: TextAlignVertical.top,
-                          style: AppTextStyles.bodyBody2Rg.copyWith(
-                            color: AppColors.gray800,
+        return Container(
+          color: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isReplyMode)
+                _ReplyTopBar(nickName: replyNickname ?? ''), //대댓글 인 경우
+              Container(
+                decoration: BoxDecoration(
+                  color: AppColors.gray100,
+                  borderRadius:
+                      isReplyMode
+                          ? BorderRadius.circular(8)
+                          : const BorderRadius.only(
+                            bottomLeft: Radius.circular(8),
+                            bottomRight: Radius.circular(8),
                           ),
-                          decoration: InputDecoration(
-                            isDense: true,
-                            border: InputBorder.none,
-                            hintText: '댓글로 의견을 남겨보세요.',
-                            hintStyle: AppTextStyles.bodyBody2Rg.copyWith(
-                              color: AppColors.gray600,
-                            ),
-                            contentPadding: EdgeInsets.zero,
+                ),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                child: Row(
+                  spacing: 8,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: controller,
+                        focusNode: focusNode,
+                        cursorColor: AppColors.primary700,
+                        minLines: 1,
+                        maxLines: maxLines, // ✅ 4줄까지는 높이 증가, 이후는 내부 스크롤
+                        keyboardType: TextInputType.multiline,
+                        textAlignVertical: TextAlignVertical.top,
+                        style: AppTextStyles.bodyBody2Rg.copyWith(
+                          color: AppColors.gray800,
+                        ),
+                        decoration: InputDecoration(
+                          isDense: true,
+                          border: InputBorder.none,
+                          hintText: '댓글로 의견을 남겨보세요.',
+                          hintStyle: AppTextStyles.bodyBody2Rg.copyWith(
+                            color: AppColors.gray600,
                           ),
+                          contentPadding: EdgeInsets.zero,
                         ),
                       ),
-                      _SendButton(
-                        enabled: hasText,
-                        onTap: hasText ? onPressed : null,
-                      ),
-                    ],
-                  ),
+                    ),
+                    _SendButton(
+                      enabled: hasText,
+                      onTap:
+                          hasText
+                              ? () {
+                                onPressed();
+                                FocusManager.instance.primaryFocus?.unfocus();
+                              }
+                              : null,
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         );
       },

--- a/lib/feature/community/widgets/comment/comment_item.dart
+++ b/lib/feature/community/widgets/comment/comment_item.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/model/comment.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+import 'comment_shared_widgets.dart';
+import 'reply_item.dart';
+
+class CommentItem extends StatelessWidget {
+  final Comment comment;
+  final bool isReplying;
+  final VoidCallback onTapReply;
+  final VoidCallback onToggleLike;
+  final VoidCallback onTapMore;
+  final List<Comment> replies;
+  final void Function(Comment reply) onToggleReplyLike;
+  final void Function(Comment reply) onTapReplyMore;
+
+  const CommentItem({
+    super.key,
+    required this.comment,
+    required this.isReplying,
+    required this.onTapReply,
+    required this.onToggleLike,
+    required this.onTapMore,
+    required this.replies,
+    required this.onToggleReplyLike,
+    required this.onTapReplyMore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: isReplying ? AppColors.primary100 : Colors.white,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 0),
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+      child: Column(
+        spacing: 8,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            spacing: 8,
+            children: [
+              //프로필 이미지
+              CircleAvatar(
+                radius: 12,
+                backgroundColor: AppColors.gray200,
+                backgroundImage:
+                    (comment.profileUrl != null &&
+                            comment.profileUrl!.isNotEmpty)
+                        ? NetworkImage(comment.profileUrl!)
+                        : null,
+              ),
+              Expanded(
+                child: Text(
+                  comment.nickName,
+                  style: AppTextStyles.headHead8Sb.copyWith(
+                    color: AppColors.gray800,
+                  ),
+                ),
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  color: AppColors.gray100,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    //대댓글 버튼
+                    CommentReplyButton(onTap: onTapReply),
+                    const CommentVBar(),
+                    //좋아요 버튼
+                    CommentLikeButton(
+                      isActive: comment.likedByMe,
+                      onTap: onToggleLike,
+                    ),
+                    const CommentVBar(),
+                    //더보기 버튼
+                    CommentMoreButton(onTap: onTapMore),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          //댓글 내용
+          Text(
+            comment.content,
+            style: AppTextStyles.bodyBody2Rg.copyWith(color: AppColors.gray800),
+          ),
+          //작성 시간
+          Text(
+            comment.createdAt ?? '',
+            style: AppTextStyles.bodyBody4M.copyWith(color: AppColors.gray600),
+          ),
+          if (replies.isNotEmpty) ...[
+            Column(
+              spacing: 12,
+              children:
+                  replies
+                      .map(
+                        (reply) => ReplyItem(
+                          reply: reply,
+                          onToggleLike: () => onToggleReplyLike(reply),
+                          onTapMore: () => onTapReplyMore(reply),
+                        ),
+                      )
+                      .toList(),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/comment/comment_list.dart
+++ b/lib/feature/community/widgets/comment/comment_list.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/model/comment.dart';
+import 'package:inninglog/feature/community/widgets/comment/comment_item.dart';
+import 'package:inninglog/feature/community/widgets/comment/empty_comment.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+
+class CommentList extends StatelessWidget {
+  final List<Comment> comments;
+  final int? activeReplyIndex;
+  final List<Comment> Function(int index) repliesFor;
+  final void Function(int index) onTapReply;
+  final void Function(int index) onToggleLike;
+  final void Function(Comment reply, int index) onToggleReplyLike;
+  final void Function(Comment comment) onTapMore;
+  final void Function(Comment reply) onTapReplyMore;
+
+  const CommentList({
+    super.key,
+    required this.comments,
+    required this.activeReplyIndex,
+    required this.repliesFor,
+    required this.onTapReply,
+    required this.onToggleLike,
+    required this.onToggleReplyLike,
+    required this.onTapMore,
+    required this.onTapReplyMore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (comments.isEmpty) return const EmptyComment();
+
+    return Column(
+      children:
+          comments.asMap().entries.expand((entry) {
+            final index = entry.key;
+            final comment = entry.value;
+            return [
+              if (index > 0)
+                const Divider(height: 8, color: AppColors.gray200),
+              CommentItem(
+                comment: comment,
+                isReplying: activeReplyIndex == index,
+                onTapReply: () => onTapReply(index),
+                onToggleLike: () => onToggleLike(index),
+                onTapMore: () => onTapMore(comment),
+                replies: repliesFor(index),
+                onToggleReplyLike: (reply) => onToggleReplyLike(reply, index),
+                onTapReplyMore: onTapReplyMore,
+              ),
+            ];
+          }).toList(),
+    );
+  }
+}

--- a/lib/feature/community/widgets/comment/comment_shared_widgets.dart
+++ b/lib/feature/community/widgets/comment/comment_shared_widgets.dart
@@ -28,12 +28,7 @@ class CommentVBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 1,
-      height: 10,
-      margin: const EdgeInsets.symmetric(horizontal: 8),
-      color: AppColors.gray400,
-    );
+    return Container(width: 1, height: 10, color: AppColors.gray400);
   }
 }
 

--- a/lib/feature/community/widgets/comment/comment_shared_widgets.dart
+++ b/lib/feature/community/widgets/comment/comment_shared_widgets.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+
+class CommentIconButtonBox extends StatelessWidget {
+  final VoidCallback onTap;
+  final Widget child;
+
+  const CommentIconButtonBox({
+    super.key,
+    required this.onTap,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+
+      child: SizedBox(width: 34, height: 24, child: Center(child: child)),
+    );
+  }
+}
+
+class CommentVBar extends StatelessWidget {
+  const CommentVBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      height: 10,
+      margin: const EdgeInsets.symmetric(horizontal: 8),
+      color: AppColors.gray400,
+    );
+  }
+}
+
+class CommentReplyButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const CommentReplyButton({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return CommentIconButtonBox(
+      onTap: onTap,
+      child: SvgPicture.asset(
+        'assets/icons/board_comment.svg',
+        width: 14,
+        height: 12,
+        colorFilter: const ColorFilter.mode(AppColors.gray400, BlendMode.srcIn),
+      ),
+    );
+  }
+}
+
+class CommentLikeButton extends StatelessWidget {
+  final bool isActive;
+  final VoidCallback onTap;
+
+  const CommentLikeButton({
+    super.key,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CommentIconButtonBox(
+      onTap: onTap,
+      child: SvgPicture.asset(
+        'assets/icons/board_heart.svg',
+        width: 14,
+        height: 12,
+        colorFilter: ColorFilter.mode(
+          isActive ? AppColors.primary700 : AppColors.gray400,
+          BlendMode.srcIn,
+        ),
+      ),
+    );
+  }
+}
+
+class CommentMoreButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const CommentMoreButton({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return CommentIconButtonBox(
+      onTap: onTap,
+      child: const Icon(Icons.more_vert, size: 14, color: AppColors.gray400),
+    );
+  }
+}

--- a/lib/feature/community/widgets/comment/empty_comment.dart
+++ b/lib/feature/community/widgets/comment/empty_comment.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+
+class EmptyComment extends StatelessWidget {
+  const EmptyComment({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.primary50,
+      padding: const EdgeInsets.only(top: 120),
+      alignment: Alignment.center,
+      child: Column(
+        children: [
+          SvgPicture.asset(
+            'assets/icons/board_bori.svg',
+            width: 60,
+            height: 60,
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            '첫 번째 댓글을 남겨주세요!',
+            style: TextStyle(
+              fontSize: 16,
+              color: AppColors.gray600,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/comment/empty_comment.dart
+++ b/lib/feature/community/widgets/comment/empty_comment.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
 
 class EmptyComment extends StatelessWidget {
   const EmptyComment({super.key});
@@ -19,13 +20,9 @@ class EmptyComment extends StatelessWidget {
             height: 60,
           ),
           const SizedBox(height: 24),
-          const Text(
+          Text(
             '첫 번째 댓글을 남겨주세요!',
-            style: TextStyle(
-              fontSize: 16,
-              color: AppColors.gray600,
-              fontWeight: FontWeight.w400,
-            ),
+            style: AppTextStyles.bodyBody1Rg.copyWith(color: AppColors.gray600),
           ),
         ],
       ),

--- a/lib/feature/community/widgets/comment/reply_item.dart
+++ b/lib/feature/community/widgets/comment/reply_item.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/feature/community/model/comment.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+import 'comment_shared_widgets.dart';
+
+class ReplyItem extends StatelessWidget {
+  final Comment reply;
+  final VoidCallback onToggleLike;
+  final VoidCallback onTapMore;
+
+  const ReplyItem({
+    super.key,
+    required this.reply,
+    required this.onToggleLike,
+    required this.onTapMore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 8,
+        children: [
+          //대댓글 화살표
+          SvgPicture.asset(
+            'assets/icons/board_reply.svg',
+            width: 11,
+            height: 15,
+            colorFilter: const ColorFilter.mode(
+              AppColors.gray300,
+              BlendMode.srcIn,
+            ),
+          ),
+          //대댓글 아이템
+          Expanded(
+            child: Column(
+              spacing: 8,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  spacing: 8,
+                  children: [
+                    //프로필 이미지
+                    CircleAvatar(
+                      radius: 12,
+                      backgroundColor: AppColors.gray200,
+                      backgroundImage:
+                          (reply.profileUrl != null &&
+                                  reply.profileUrl!.isNotEmpty)
+                              ? NetworkImage(reply.profileUrl!)
+                              : null,
+                    ),
+                    Expanded(
+                      child: Text(
+                        reply.nickName,
+                        style: AppTextStyles.headHead8Sb.copyWith(
+                          color: AppColors.gray800,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      decoration: BoxDecoration(
+                        color: AppColors.gray200,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          //좋아요 버튼
+                          CommentLikeButton(
+                            isActive: reply.likedByMe,
+                            onTap: onToggleLike,
+                          ),
+                          const CommentVBar(),
+                          //더보기 버튼
+                          CommentMoreButton(onTap: onTapMore),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                //댓글 내용
+                Text(
+                  reply.content,
+                  style: AppTextStyles.bodyBody2Rg.copyWith(
+                    color: AppColors.gray800,
+                  ),
+                ),
+                //작성 시간
+                Text(
+                  reply.createdAt ?? '',
+                  style: AppTextStyles.bodyBody4M.copyWith(
+                    color: AppColors.gray600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/comment/reply_item.dart
+++ b/lib/feature/community/widgets/comment/reply_item.dart
@@ -32,7 +32,7 @@ class ReplyItem extends StatelessWidget {
             width: 11,
             height: 15,
             colorFilter: const ColorFilter.mode(
-              AppColors.gray300,
+              AppColors.gray600,
               BlendMode.srcIn,
             ),
           ),

--- a/lib/feature/community/widgets/comment/reply_item.dart
+++ b/lib/feature/community/widgets/comment/reply_item.dart
@@ -38,67 +38,74 @@ class ReplyItem extends StatelessWidget {
           ),
           //대댓글 아이템
           Expanded(
-            child: Column(
-              spacing: 8,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  spacing: 8,
-                  children: [
-                    //프로필 이미지
-                    CircleAvatar(
-                      radius: 12,
-                      backgroundColor: AppColors.gray200,
-                      backgroundImage:
-                          (reply.profileUrl != null &&
-                                  reply.profileUrl!.isNotEmpty)
-                              ? NetworkImage(reply.profileUrl!)
-                              : null,
-                    ),
-                    Expanded(
-                      child: Text(
-                        reply.nickName,
-                        style: AppTextStyles.headHead8Sb.copyWith(
-                          color: AppColors.gray800,
+            child: Container(
+              decoration: BoxDecoration(
+                color: AppColors.gray100,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              padding: EdgeInsets.all(8),
+              child: Column(
+                spacing: 8,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    spacing: 8,
+                    children: [
+                      //프로필 이미지
+                      CircleAvatar(
+                        radius: 12,
+                        backgroundColor: AppColors.gray200,
+                        backgroundImage:
+                            (reply.profileUrl != null &&
+                                    reply.profileUrl!.isNotEmpty)
+                                ? NetworkImage(reply.profileUrl!)
+                                : null,
+                      ),
+                      Expanded(
+                        child: Text(
+                          reply.nickName,
+                          style: AppTextStyles.headHead8Sb.copyWith(
+                            color: AppColors.gray800,
+                          ),
                         ),
                       ),
-                    ),
-                    Container(
-                      decoration: BoxDecoration(
-                        color: AppColors.gray200,
-                        borderRadius: BorderRadius.circular(4),
+                      Container(
+                        decoration: BoxDecoration(
+                          color: AppColors.gray200,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            //좋아요 버튼
+                            CommentLikeButton(
+                              isActive: reply.likedByMe,
+                              onTap: onToggleLike,
+                            ),
+                            const CommentVBar(),
+                            //더보기 버튼
+                            CommentMoreButton(onTap: onTapMore),
+                          ],
+                        ),
                       ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          //좋아요 버튼
-                          CommentLikeButton(
-                            isActive: reply.likedByMe,
-                            onTap: onToggleLike,
-                          ),
-                          const CommentVBar(),
-                          //더보기 버튼
-                          CommentMoreButton(onTap: onTapMore),
-                        ],
-                      ),
+                    ],
+                  ),
+                  //댓글 내용
+                  Text(
+                    reply.content,
+                    style: AppTextStyles.bodyBody2Rg.copyWith(
+                      color: AppColors.gray800,
                     ),
-                  ],
-                ),
-                //댓글 내용
-                Text(
-                  reply.content,
-                  style: AppTextStyles.bodyBody2Rg.copyWith(
-                    color: AppColors.gray800,
                   ),
-                ),
-                //작성 시간
-                Text(
-                  reply.createdAt ?? '',
-                  style: AppTextStyles.bodyBody4M.copyWith(
-                    color: AppColors.gray600,
+                  //작성 시간
+                  Text(
+                    reply.createdAt ?? '',
+                    style: AppTextStyles.bodyBody4M.copyWith(
+                      color: AppColors.gray600,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/feature/community/widgets/post/post_item_card.dart
+++ b/lib/feature/community/widgets/post/post_item_card.dart
@@ -29,21 +29,13 @@ class PostItemCard extends StatelessWidget {
                   children: [
                     Row(
                       children: [
-                        Container(
-                          width: 26,
-                          height: 26,
-                          decoration: const BoxDecoration(
-                            color: Color(0xFFE5E7EB),
-                            shape: BoxShape.circle,
-                          ),
-                          clipBehavior: Clip.antiAlias,
-                          child:
+                        CircleAvatar(
+                          radius: 13,
+                          backgroundColor: AppColors.gray200,
+                          backgroundImage:
                               (item.profileUrl != null &&
                                       item.profileUrl!.isNotEmpty)
-                                  ? Image.network(
-                                    item.profileUrl!,
-                                    fit: BoxFit.cover,
-                                  )
+                                  ? NetworkImage(item.profileUrl!)
                                   : null,
                         ),
                         const SizedBox(width: 8),

--- a/lib/feature/community/widgets/post_detail/post_header_section.dart
+++ b/lib/feature/community/widgets/post_detail/post_header_section.dart
@@ -70,17 +70,12 @@ class PostAuthorRow extends StatelessWidget {
     return Row(
       spacing: 8,
       children: [
-        Container(
-          width: 40,
-          height: 40,
-          decoration: const BoxDecoration(
-            color: Color(0xFFE5E7EB),
-            shape: BoxShape.circle,
-          ),
-          clipBehavior: Clip.antiAlias,
-          child:
+        CircleAvatar(
+          radius: 20,
+          backgroundColor: AppColors.gray200,
+          backgroundImage:
               (profileUrl != null && profileUrl!.isNotEmpty)
-                  ? Image.network(profileUrl!, fit: BoxFit.cover)
+                  ? NetworkImage(profileUrl!)
                   : null,
         ),
         Column(

--- a/lib/feature/login/models/KakaoLoginWebViewPage.dart
+++ b/lib/feature/login/models/KakaoLoginWebViewPage.dart
@@ -38,15 +38,15 @@ class _KakaoLoginWebViewPageState extends State<KakaoLoginWebViewPage> {
           ..setNavigationDelegate(
             NavigationDelegate(
               onPageStarted: (url) {
-                _log('[WEBVIEW] onPageStarted: $url');
+                // _log('[WEBVIEW] onPageStarted: $url');
                 if (mounted) setState(() => _loading = true);
               },
               onWebResourceError: (err) {
-                _log('[WEBVIEW ERROR] $err');
+                // _log('[WEBVIEW ERROR] $err');
                 _showSnack('웹뷰 오류: ${err.description}');
               },
               onPageFinished: (url) async {
-                _log('[WEBVIEW] onPageFinished: $url');
+                // _log('[WEBVIEW] onPageFinished: $url');
                 if (mounted) setState(() => _loading = false);
 
                 // 1) /login/page → location 파싱 후 카카오 인증 URL로 이동
@@ -74,12 +74,12 @@ class _KakaoLoginWebViewPageState extends State<KakaoLoginWebViewPage> {
   Future<void> _handleLoginPage() async {
     try {
       final bodyText = await _readBodyInnerText();
-      _log('[LOGIN PAGE BODY] $bodyText');
+      // _log('[LOGIN PAGE BODY] $bodyText');
 
       final map = jsonDecode(bodyText) as Map<String, dynamic>;
       final location = (map['location'] as String?)?.trim();
 
-      _log('[LOGIN PAGE LOCATION] $location');
+      // _log('[LOGIN PAGE LOCATION] $location');
 
       if (location != null && location.isNotEmpty) {
         _kakaoAuthLaunched = true;
@@ -88,7 +88,7 @@ class _KakaoLoginWebViewPageState extends State<KakaoLoginWebViewPage> {
         _showSnack('location이 비어있습니다.');
       }
     } catch (e) {
-      _log('[LOGIN PAGE PARSE ERROR] $e');
+      // _log('[LOGIN PAGE PARSE ERROR] $e');
       _showSnack('로그인 URL 파싱 실패: $e');
     }
   }
@@ -96,7 +96,7 @@ class _KakaoLoginWebViewPageState extends State<KakaoLoginWebViewPage> {
   Future<void> _handleCallback() async {
     try {
       final bodyText = await _readBodyInnerText();
-      _log('[CALLBACK BODY] $bodyText');
+      // _log('[CALLBACK BODY] $bodyText');
 
       final map = jsonDecode(bodyText) as Map<String, dynamic>;
 
@@ -107,14 +107,14 @@ class _KakaoLoginWebViewPageState extends State<KakaoLoginWebViewPage> {
       final memberId = JwtUtils.extractMemberId(session.accessToken);
       session = session.copyWith(memberId: memberId);
 
-      if (kDebugMode) {
-        _log('[CALLBACK nickname] ${session.nickname}');
-        _log('[CALLBACK newMember] ${session.isNewMember}');
-        _log('[CALLBACK memberId] ${session.memberId}');
-        _log(
-          '[CALLBACK TOKEN PAYLOAD] ${JwtUtils.decodePayload(session.accessToken)}',
-        );
-      }
+      // if (kDebugMode) {
+      //   _log('[CALLBACK nickname] ${session.nickname}');
+      //   _log('[CALLBACK newMember] ${session.isNewMember}');
+      //   _log('[CALLBACK memberId] ${session.memberId}');
+      //   _log(
+      //     '[CALLBACK TOKEN PAYLOAD] ${JwtUtils.decodePayload(session.accessToken)}',
+      //   );
+      // }
 
       // 3) 저장 (SharedPreferences 직접 접근 제거)
       await _scope.tokenStorage.saveSession(session);
@@ -127,7 +127,7 @@ class _KakaoLoginWebViewPageState extends State<KakaoLoginWebViewPage> {
       if (!mounted) return;
       context.go(session.isNewMember ? '/onboarding6' : '/home');
     } catch (e) {
-      _log('[CALLBACK PARSE ERROR] $e');
+      // _log('[CALLBACK PARSE ERROR] $e');
       _showSnack('콜백 처리 실패: $e');
     }
   }
@@ -150,14 +150,14 @@ class _KakaoLoginWebViewPageState extends State<KakaoLoginWebViewPage> {
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
   }
 
-  void _log(String msg) {
-    const chunk = 1024;
-    for (var i = 0; i < msg.length; i += chunk) {
-      debugPrint(
-        msg.substring(i, (i + chunk > msg.length) ? msg.length : i + chunk),
-      );
-    }
-  }
+  // void _log(String msg) {
+  //   const chunk = 1024;
+  //   for (var i = 0; i < msg.length; i += chunk) {
+  //     debugPrint(
+  //       msg.substring(i, (i + chunk > msg.length) ? msg.length : i + chunk),
+  //     );
+  //   }
+  // }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## 🎯요약(Summary)
- 커뮤니티 게시글 댓글 화면 UI를 구현하고, 댓글 생성/조회 API 연동 및 기능 테스트를 진행했습니다.

## 💻 상세 내용(Describe your changes)
- 댓글 UI는 오직완에서도 재사용되므로 PostDetailPage에서 댓글 관련 위젯을 분리
- Comment 모델 & DTO 추가
- Comment 생성/조회 API 함수 구성
- Post Comment 상태 모델 로직 구성 및 UI 연동
- 댓글/대댓글 입력 시 키보드 inset에 따라 화면 스크롤 위치 조정되도록 UX 개선

## 📸 스크린샷
| 일반 댓글 입력 시 | 대댓글 입력 시 |
| -------| -------|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/60a101e1-58d8-42c6-a7f8-d9e90166573c" /> | <img width="300"  alt="image" src="https://github.com/user-attachments/assets/1f74f109-8eed-472f-ad2c-e782e9736ae8" /> |


## 📌 관련 이슈번호(Related Issue)
- closed: #71 

## ✅ TODO
- [ ] 댓글 삭제 기능
- [ ] 댓글 좋아요 기능 
