### PR TITLE
[FEAT] 오직완 직관일지 아이템/리스트 위젯 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ app.*.map.json
 
 
 .env
+mcp.json
+config.toml

--- a/lib/app_scope.dart
+++ b/lib/app_scope.dart
@@ -1,4 +1,5 @@
 import 'package:inninglog/feature/community/repositories/comment_repository.dart';
+import 'package:inninglog/feature/community/repositories/diary_repository.dart';
 import 'package:inninglog/feature/community/repositories/post_repository.dart';
 import 'package:inninglog/feature/user/repositories/user_repository.dart';
 import 'package:inninglog/shared/auth/token_storage.dart';
@@ -12,6 +13,7 @@ class AppScope {
       CommunityPostRepository(apiClient.dio);
   late final CommentRepository commentRepository =
       CommentRepository(apiClient.dio);
+  late final DiaryRepository diaryRepository = DiaryRepository(apiClient.dio);
   late final UserRepository userRepository = UserRepository(apiClient.dio);
 
   AppScope._({required this.tokenStorage, required this.apiClient});

--- a/lib/feature/community/model/diary_item.dart
+++ b/lib/feature/community/model/diary_item.dart
@@ -1,0 +1,30 @@
+class DiaryItemModel {
+  final String journalId;
+  final String? thumbImageUrl;
+  final String content;
+  final String nickName;
+
+  final String? profileUrl;
+  final bool writeByMe;
+  final int likeCount;
+  final bool likedByMe;
+  final int scrapCount;
+  final bool scrapedByMe;
+  final int commentCount;
+  final String? createdAt;
+
+  const DiaryItemModel({
+    required this.journalId,
+    required this.content,
+    required this.nickName,
+    this.profileUrl,
+    this.writeByMe = false,
+    this.likeCount = 0,
+    this.likedByMe = false,
+    this.scrapCount = 0,
+    this.scrapedByMe = false,
+    this.commentCount = 0,
+    this.createdAt,
+    this.thumbImageUrl,
+  });
+}

--- a/lib/feature/community/model/dto/diary_dtos.dart
+++ b/lib/feature/community/model/dto/diary_dtos.dart
@@ -1,0 +1,108 @@
+import 'package:inninglog/feature/community/model/diary_item.dart';
+
+class DiaryFeedResponse {
+  final List<DiaryFeedItemDto> content;
+  final bool hasNext;
+  final int page;
+  final int size;
+
+  const DiaryFeedResponse({
+    required this.content,
+    required this.hasNext,
+    required this.page,
+    required this.size,
+  });
+
+  factory DiaryFeedResponse.fromJson(Map<String, dynamic> json) {
+    final body = (json['data'] as Map<String, dynamic>?) ?? json;
+    final content =
+        (body['content'] as List<dynamic>? ?? const [])
+            .whereType<Map<String, dynamic>>()
+            .map(DiaryFeedItemDto.fromJson)
+            .toList();
+
+    return DiaryFeedResponse(
+      content: content,
+      hasNext: body['hasNext'] == true,
+      page: (body['page'] ?? 0) as int,
+      size: (body['size'] ?? content.length) as int,
+    );
+  }
+}
+
+class DiaryFeedItemDto {
+  final String journalId;
+  final String? thumbnailUrl;
+  final DiaryFeedMemberDto member;
+  final bool writedByMe;
+  final String reviewPreview;
+  final String? createdAt;
+  final int likeCount;
+  final bool likedByMe;
+  final int commentCount;
+  final int scrapCount;
+  final bool scrapedByMe;
+
+  const DiaryFeedItemDto({
+    required this.journalId,
+    required this.member,
+    required this.writedByMe,
+    required this.reviewPreview,
+    required this.createdAt,
+    required this.likeCount,
+    required this.likedByMe,
+    required this.commentCount,
+    required this.scrapCount,
+    required this.scrapedByMe,
+    this.thumbnailUrl,
+  });
+
+  factory DiaryFeedItemDto.fromJson(Map<String, dynamic> json) {
+    return DiaryFeedItemDto(
+      journalId: (json['journalId'] ?? '').toString(),
+      thumbnailUrl: json['thumbnailUrl'] as String?,
+      member: DiaryFeedMemberDto.fromJson(
+        (json['member'] as Map<String, dynamic>? ?? const {}),
+      ),
+      writedByMe: json['writedByMe'] == true,
+      reviewPreview: (json['reviewPreview'] ?? '').toString(),
+      createdAt: json['createdAt'] as String?,
+      likeCount: (json['likeCount'] ?? 0) as int,
+      likedByMe: json['likedByMe'] == true,
+      commentCount: (json['commentCount'] ?? 0) as int,
+      scrapCount: (json['scrapCount'] ?? 0) as int,
+      scrapedByMe: json['scrapedByMe'] == true,
+    );
+  }
+
+  DiaryItemModel toModel() {
+    return DiaryItemModel(
+      journalId: journalId,
+      content: reviewPreview,
+      nickName: member.nickName,
+      profileUrl: member.profileUrl,
+      writeByMe: writedByMe,
+      likeCount: likeCount,
+      likedByMe: likedByMe,
+      scrapCount: scrapCount,
+      scrapedByMe: scrapedByMe,
+      commentCount: commentCount,
+      createdAt: createdAt,
+      thumbImageUrl: thumbnailUrl,
+    );
+  }
+}
+
+class DiaryFeedMemberDto {
+  final String nickName;
+  final String? profileUrl;
+
+  const DiaryFeedMemberDto({required this.nickName, this.profileUrl});
+
+  factory DiaryFeedMemberDto.fromJson(Map<String, dynamic> json) {
+    return DiaryFeedMemberDto(
+      nickName: (json['nickName'] ?? '').toString(),
+      profileUrl: json['profile_url'] as String?,
+    );
+  }
+}

--- a/lib/feature/community/repositories/diary_repository.dart
+++ b/lib/feature/community/repositories/diary_repository.dart
@@ -1,0 +1,32 @@
+import 'package:dio/dio.dart';
+import 'package:inninglog/feature/community/model/dto/diary_dtos.dart';
+import 'package:inninglog/shared/network/api_envelope.dart';
+
+class DiaryRepository {
+  final Dio _dio;
+  DiaryRepository(this._dio);
+
+  Future<DiaryFeedResponse> getDiaryFeed({
+    required String teamCode,
+    required int page,
+    required int size,
+  }) async {
+    final res = await _dio.get(
+      '/journals/feed',
+      queryParameters: {'teamShortCode': teamCode, 'page': page, 'size': size},
+    );
+
+    final json = res.data;
+    if (json is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected feed response shape');
+    }
+
+    final envelope = ApiEnvelope.fromJson(json);
+    final data = envelope.data;
+    if (data is Map<String, dynamic>) {
+      return DiaryFeedResponse.fromJson(data);
+    }
+
+    return DiaryFeedResponse.fromJson(json);
+  }
+}

--- a/lib/feature/community/screens/post_detail_page.dart
+++ b/lib/feature/community/screens/post_detail_page.dart
@@ -142,7 +142,7 @@ class _PostDetailPageState extends State<PostDetailPage>
     if (!mounted) return;
 
     if (success) {
-      context.read<PostDetailViewModel>().updateCommentCount(-1);
+      _vm.updateCommentCount(-1);
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('댓글이 삭제되었습니다.')),
       );

--- a/lib/feature/community/screens/tabs/free_board_tab.dart
+++ b/lib/feature/community/screens/tabs/free_board_tab.dart
@@ -26,6 +26,7 @@ class FreeBoardTab extends StatefulWidget {
 class _FreeBoardTabState extends State<FreeBoardTab> with RouteAware {
   bool _initialized = false;
   NavigatorObserver? _subscribedObserver;
+  ModalRoute<dynamic>? _route;
   late final PostListViewModel _vm;
 
   @override
@@ -39,6 +40,7 @@ class _FreeBoardTabState extends State<FreeBoardTab> with RouteAware {
 
     // 상세/작성 페이지에서 돌아올 때 pop 이벤트를 받을 수 있도록
     // 현재 네비게이터에 맞는 observer를 구독한다.
+    _route ??= ModalRoute.of(context);
     _subscribeRouteObserver();
   }
 
@@ -60,7 +62,7 @@ class _FreeBoardTabState extends State<FreeBoardTab> with RouteAware {
 
   @override
   void dispose() {
-    final route = ModalRoute.of(context);
+    final route = _route;
     if (route != null && _subscribedObserver != null) {
       if (_subscribedObserver == shellRouteObserver) {
         shellRouteObserver.unsubscribe(this);

--- a/lib/feature/community/screens/tabs/onlywan_tab.dart
+++ b/lib/feature/community/screens/tabs/onlywan_tab.dart
@@ -1,57 +1,71 @@
 import 'package:flutter/material.dart';
-import 'package:inninglog/feature/community/model/diary_item.dart';
+import 'package:inninglog/app_scope.dart';
+import 'package:inninglog/feature/community/viewmodel/diary_feed_view_model.dart';
 import 'package:inninglog/feature/community/widgets/onlywan/diary_list.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:provider/provider.dart';
 
-class OnlyWanTab extends StatelessWidget {
+class OnlyWanTab extends StatefulWidget {
+  final String teamCode;
   final bool isActive;
 
-  const OnlyWanTab({super.key, this.isActive = false});
+  const OnlyWanTab({super.key, required this.teamCode, this.isActive = false});
+
+  @override
+  State<OnlyWanTab> createState() => _OnlyWanTabState();
+}
+
+class _OnlyWanTabState extends State<OnlyWanTab> {
+  bool _initialized = false;
+  late final DiaryFeedViewModel _vm;
+
+  @override
+  void initState() {
+    super.initState();
+    final repo = context.read<AppScope>().diaryRepository;
+    _vm = DiaryFeedViewModel(repo: repo, teamCode: widget.teamCode);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_initialized) {
+      _initialized = true;
+      _vm.ensureLoaded();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant OnlyWanTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!oldWidget.isActive && widget.isActive) {
+      _vm.refresh();
+    }
+  }
+
+  @override
+  void dispose() {
+    _vm.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final items = <DiaryItemModel>[
-      const DiaryItemModel(
-        journalId: '1',
-        nickName: '닉네임 몇 자까지 되더라',
-        content: '본문 보여지는 건 공백 포함 최대 32자 / 33부턴 ... (...포함 총 36)',
-        createdAt: '3분전',
-        likeCount: 2,
-        likedByMe: true,
-        commentCount: 22,
-        scrapCount: 2,
-        scrapedByMe: false,
-        thumbImageUrl: null,
+    return ChangeNotifierProvider.value(
+      value: _vm,
+      child: Consumer<DiaryFeedViewModel>(
+        builder: (context, vm, _) {
+          return Container(
+            color: AppColors.primary50,
+            child: FeedList(
+              items: vm.items,
+              hasNext: vm.hasNext,
+              isLoading: vm.isLoading,
+              onLoadMore: vm.loadMore,
+            ),
+          );
+        },
       ),
-      const DiaryItemModel(
-        journalId: '2',
-        nickName: '오직완 유저',
-        content: '오늘도 직관 가는 사람 있나요?!!',
-        createdAt: '10분전',
-        likeCount: 8,
-        likedByMe: false,
-        commentCount: 3,
-        scrapCount: 1,
-        scrapedByMe: true,
-        thumbImageUrl: null,
-      ),
-      const DiaryItemModel(
-        journalId: '3',
-        nickName: '야구는직관',
-        content: '현장 응원 소리 미쳤다...',
-        createdAt: '30분전',
-        likeCount: 41,
-        likedByMe: false,
-        commentCount: 9,
-        scrapCount: 6,
-        scrapedByMe: false,
-        thumbImageUrl: null,
-      ),
-    ];
-
-    return Container(
-      color: AppColors.primary50,
-      child: FeedList(items: items),
     );
   }
 }

--- a/lib/feature/community/screens/tabs/onlywan_tab.dart
+++ b/lib/feature/community/screens/tabs/onlywan_tab.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/model/diary_item.dart';
+import 'package:inninglog/feature/community/widgets/onlywan/diary_list.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+
+class OnlyWanTab extends StatelessWidget {
+  final bool isActive;
+
+  const OnlyWanTab({super.key, this.isActive = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = <DiaryItemModel>[
+      const DiaryItemModel(
+        journalId: '1',
+        nickName: '닉네임 몇 자까지 되더라',
+        content: '본문 보여지는 건 공백 포함 최대 32자 / 33부턴 ... (...포함 총 36)',
+        createdAt: '3분전',
+        likeCount: 2,
+        likedByMe: true,
+        commentCount: 22,
+        scrapCount: 2,
+        scrapedByMe: false,
+        thumbImageUrl: null,
+      ),
+      const DiaryItemModel(
+        journalId: '2',
+        nickName: '오직완 유저',
+        content: '오늘도 직관 가는 사람 있나요?!!',
+        createdAt: '10분전',
+        likeCount: 8,
+        likedByMe: false,
+        commentCount: 3,
+        scrapCount: 1,
+        scrapedByMe: true,
+        thumbImageUrl: null,
+      ),
+      const DiaryItemModel(
+        journalId: '3',
+        nickName: '야구는직관',
+        content: '현장 응원 소리 미쳤다...',
+        createdAt: '30분전',
+        likeCount: 41,
+        likedByMe: false,
+        commentCount: 9,
+        scrapCount: 6,
+        scrapedByMe: false,
+        thumbImageUrl: null,
+      ),
+    ];
+
+    return Container(
+      color: AppColors.primary50,
+      child: FeedList(items: items),
+    );
+  }
+}

--- a/lib/feature/community/screens/teamboard_page.dart
+++ b/lib/feature/community/screens/teamboard_page.dart
@@ -9,6 +9,7 @@ import 'package:inninglog/shared/theme/app_colors.dart';
 import 'package:inninglog/feature/community/screens/post_detail_market.dart';
 import 'package:inninglog/shared/widgets/common_header.dart';
 import 'tabs/free_board_tab.dart';
+import 'tabs/onlywan_tab.dart';
 
 enum BoardMode { normal, myPosts, myComments, scraps }
 
@@ -129,7 +130,7 @@ class _TeamBoardPageState extends State<TeamBoardPage>
                   final isActive = index == _tabController.index;
                   switch (tab.type) {
                     case BoardTab.onlywan:
-                      return const Center(child: Text('오직완 페이지'));
+                      return OnlyWanTab(isActive: isActive);
                     case BoardTab.free:
                       return FreeBoardTab(
                         teamCode: widget.teamCode,

--- a/lib/feature/community/screens/teamboard_page.dart
+++ b/lib/feature/community/screens/teamboard_page.dart
@@ -88,23 +88,34 @@ class _TeamBoardPageState extends State<TeamBoardPage>
 
   @override
   Widget build(BuildContext context) {
+    final isFreeTab = _tabs[_tabController.index].type == BoardTab.free;
     return Scaffold(
       backgroundColor: AppColors.primary50,
-      floatingActionButton: SizedBox(
-        width: 56,
-        height: 56,
-
-        child: FloatingActionButton(
-          backgroundColor: AppColors.primary700,
-          shape: const CircleBorder(),
-          onPressed: () {
-            // 기존 게시판 글쓰기
-            context.push(AppRoutePaths.boardPostWriteLocation(widget.teamCode));
-            debugPrint('[Team Board Page] teamCode: ${widget.teamCode}');
-          },
-          child: const Icon(Icons.add, size: 40, color: AppColors.primary50),
-        ),
-      ),
+      floatingActionButton:
+          isFreeTab
+              ? SizedBox(
+                width: 56,
+                height: 56,
+                child: FloatingActionButton(
+                  backgroundColor: AppColors.primary700,
+                  shape: const CircleBorder(),
+                  onPressed: () {
+                    // 기존 게시판 글쓰기
+                    context.push(
+                      AppRoutePaths.boardPostWriteLocation(widget.teamCode),
+                    );
+                    debugPrint(
+                      '[Team Board Page] teamCode: ${widget.teamCode}',
+                    );
+                  },
+                  child: const Icon(
+                    Icons.add,
+                    size: 40,
+                    color: AppColors.primary50,
+                  ),
+                ),
+              )
+              : null,
 
       body: SafeArea(
         child: Column(
@@ -130,7 +141,10 @@ class _TeamBoardPageState extends State<TeamBoardPage>
                   final isActive = index == _tabController.index;
                   switch (tab.type) {
                     case BoardTab.onlywan:
-                      return OnlyWanTab(isActive: isActive);
+                      return OnlyWanTab(
+                        isActive: isActive,
+                        teamCode: widget.teamCode,
+                      );
                     case BoardTab.free:
                       return FreeBoardTab(
                         teamCode: widget.teamCode,

--- a/lib/feature/community/viewmodel/diary_feed_view_model.dart
+++ b/lib/feature/community/viewmodel/diary_feed_view_model.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/model/diary_item.dart';
+import 'package:inninglog/feature/community/model/dto/diary_dtos.dart';
+import 'package:inninglog/feature/community/repositories/diary_repository.dart';
+
+class DiaryFeedViewModel extends ChangeNotifier {
+  final DiaryRepository repo;
+  final String teamCode;
+  final int pageSize;
+
+  DiaryFeedViewModel({
+    required this.repo,
+    required this.teamCode,
+    this.pageSize = 10,
+  });
+
+  final List<DiaryItemModel> _items = [];
+  List<DiaryItemModel> get items => List.unmodifiable(_items);
+
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
+
+  bool _hasNext = true;
+  bool get hasNext => _hasNext;
+
+  int _page = 0;
+  String? _error;
+  String? get error => _error;
+  bool _hasLoadedOnce = false;
+  bool get hasLoadedOnce => _hasLoadedOnce;
+
+  Future<void> refresh() => loadInitial();
+
+  Future<void> loadInitial() async {
+    _items.clear();
+    _page = 0;
+    _hasNext = true;
+    _error = null;
+    await _fetch();
+  }
+
+  Future<void> ensureLoaded() async {
+    if (_hasLoadedOnce || _isLoading) return;
+    await loadInitial();
+  }
+
+  Future<void> loadMore() async {
+    if (_isLoading || !_hasNext) return;
+    _page += 1;
+    await _fetch();
+  }
+
+  Future<void> _fetch() async {
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final DiaryFeedResponse res = await repo.getDiaryFeed(
+        teamCode: teamCode,
+        page: _page,
+        size: pageSize,
+      );
+
+      final mapped = res.content.map((e) => e.toModel()).toList();
+      if (_page == 0) {
+        _items
+          ..clear()
+          ..addAll(mapped);
+      } else {
+        _items.addAll(mapped);
+      }
+
+      _hasNext = res.hasNext;
+      _error = null;
+    } catch (e) {
+      if (_page > 0) _page -= 1;
+      _error = e.toString();
+    } finally {
+      _hasLoadedOnce = true;
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/feature/community/widgets/comment/comment_item.dart
+++ b/lib/feature/community/widgets/comment/comment_item.dart
@@ -95,7 +95,8 @@ class CommentItem extends StatelessWidget {
               Text(
                 comment.content,
                 style: AppTextStyles.bodyBody2Rg.copyWith(
-                  color: AppColors.gray800,
+                  color:
+                      comment.isDeleted ? AppColors.gray600 : AppColors.gray800,
                 ),
               ),
               Row(

--- a/lib/feature/community/widgets/comment/reply_item.dart
+++ b/lib/feature/community/widgets/comment/reply_item.dart
@@ -48,53 +48,57 @@ class ReplyItem extends StatelessWidget {
                 spacing: 8,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Row(
-                    spacing: 8,
-                    children: [
-                      //프로필 이미지
-                      CircleAvatar(
-                        radius: 12,
-                        backgroundColor: AppColors.gray200,
-                        backgroundImage:
-                            (reply.profileUrl != null &&
-                                    reply.profileUrl!.isNotEmpty)
-                                ? NetworkImage(reply.profileUrl!)
-                                : null,
-                      ),
-                      Expanded(
-                        child: Text(
-                          reply.nickName,
-                          style: AppTextStyles.headHead8Sb.copyWith(
-                            color: AppColors.gray800,
+                  if (!reply.isDeleted)
+                    Row(
+                      spacing: 8,
+                      children: [
+                        //프로필 이미지
+                        CircleAvatar(
+                          radius: 12,
+                          backgroundColor: AppColors.gray200,
+                          backgroundImage:
+                              (reply.profileUrl != null &&
+                                      reply.profileUrl!.isNotEmpty)
+                                  ? NetworkImage(reply.profileUrl!)
+                                  : null,
+                        ),
+                        Expanded(
+                          child: Text(
+                            reply.nickName,
+                            style: AppTextStyles.headHead8Sb.copyWith(
+                              color: AppColors.gray800,
+                            ),
                           ),
                         ),
-                      ),
-                      Container(
-                        decoration: BoxDecoration(
-                          color: AppColors.gray200,
-                          borderRadius: BorderRadius.circular(4),
+                        Container(
+                          decoration: BoxDecoration(
+                            color: AppColors.gray200,
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              //좋아요 버튼
+                              CommentLikeButton(
+                                isActive: reply.likedByMe,
+                                onTap: onToggleLike,
+                              ),
+                              const CommentVBar(),
+                              //더보기 버튼
+                              CommentMoreButton(onTap: onTapMore),
+                            ],
+                          ),
                         ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            //좋아요 버튼
-                            CommentLikeButton(
-                              isActive: reply.likedByMe,
-                              onTap: onToggleLike,
-                            ),
-                            const CommentVBar(),
-                            //더보기 버튼
-                            CommentMoreButton(onTap: onTapMore),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
+                      ],
+                    ),
                   //댓글 내용
                   Text(
                     reply.content,
                     style: AppTextStyles.bodyBody2Rg.copyWith(
-                      color: AppColors.gray800,
+                      color:
+                          reply.isDeleted
+                              ? AppColors.gray600
+                              : AppColors.gray800,
                     ),
                   ),
                   //작성 시간

--- a/lib/feature/community/widgets/onlywan/diary_item.dart
+++ b/lib/feature/community/widgets/onlywan/diary_item.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:inninglog/feature/community/model/diary_item.dart';
+import 'package:inninglog/feature/community/widgets/post/post_action_counts.dart';
+import 'package:inninglog/feature/community/widgets/post_detail/post_action_button.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+enum FeedImageRatio { ratio3x4, ratio1x1, ratio4x3 }
+
+class FeedItem extends StatelessWidget {
+  final DiaryItemModel item;
+  final VoidCallback? onTapMore;
+  final VoidCallback? onTap;
+  final VoidCallback? onTapLike;
+  final VoidCallback? onTapComment;
+  final VoidCallback? onTapScrap;
+
+  const FeedItem({
+    super.key,
+    required this.item,
+    this.onTapMore,
+    this.onTap,
+    this.onTapLike,
+    this.onTapComment,
+    this.onTapScrap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // final imageRatio = _ratioValue(ratio3x4);
+    return Material(
+      color: Colors.white,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
+          child: Column(
+            spacing: 8,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _HeaderRow(item: item, onTapMore: onTapMore),
+              SizedBox(
+                width: 270,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child:
+                      item.thumbImageUrl == null
+                          ? Container(color: const Color(0xFFD9D9D9))
+                          : Image.network(
+                            item.thumbImageUrl!,
+                            fit: BoxFit.cover,
+                          ),
+                ),
+              ),
+
+              Text(
+                item.content,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTextStyles.bodyBody2Rg.copyWith(
+                  color: AppColors.gray900,
+                ),
+              ),
+              _ActionRow(
+                item: item,
+                onTapLike: onTapLike,
+                onTapComment: onTapComment,
+                onTapScrap: onTapScrap,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HeaderRow extends StatelessWidget {
+  final DiaryItemModel item;
+  final VoidCallback? onTapMore;
+
+  const _HeaderRow({required this.item, this.onTapMore});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        CircleAvatar(
+          radius: 15,
+          backgroundColor: AppColors.gray200,
+          backgroundImage:
+              item.thumbImageUrl != null
+                  ? NetworkImage(item.thumbImageUrl!)
+                  : null,
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                item.nickName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTextStyles.headHead7Sb.copyWith(
+                  color: AppColors.gray800,
+                  height: 1,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                item.createdAt ?? '',
+                style: AppTextStyles.headHead8M.copyWith(
+                  color: AppColors.gray700,
+                  height: 1,
+                ),
+              ),
+            ],
+          ),
+        ),
+        InkWell(
+          onTap: onTapMore,
+          borderRadius: BorderRadius.circular(13),
+          child: SizedBox(
+            width: 26,
+            height: 26,
+            child: Center(
+              child: SvgPicture.asset(
+                'assets/icons/board_dots.svg',
+                width: 18,
+                height: 18,
+                colorFilter: const ColorFilter.mode(
+                  AppColors.gray700,
+                  BlendMode.srcIn,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionRow extends StatelessWidget {
+  final DiaryItemModel item;
+  final VoidCallback? onTapLike;
+  final VoidCallback? onTapComment;
+  final VoidCallback? onTapScrap;
+
+  const _ActionRow({
+    required this.item,
+    this.onTapLike,
+    this.onTapComment,
+    this.onTapScrap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        PostActionButton(
+          asset:
+              item.likedByMe
+                  ? 'assets/icons/board_heart.svg'
+                  : 'assets/icons/green_heart.svg',
+          color: item.likedByMe ? AppColors.primary700 : AppColors.gray800,
+          label: item.likeCount.toString(),
+          onTap: onTapLike,
+          iconSize: 14,
+          labelStyle: AppTextStyles.bodyBody3M,
+        ),
+        const SizedBox(width: 20),
+
+        PostActionButton(
+          asset: 'assets/icons/green_comment.svg',
+          color: AppColors.gray800,
+          label: item.commentCount.toString(),
+          onTap: null,
+          iconSize: 14,
+          labelStyle: AppTextStyles.bodyBody3M,
+        ),
+        const SizedBox(width: 20),
+        PostActionButton(
+          asset:
+              item.scrapedByMe
+                  ? 'assets/icons/board_scrap.svg'
+                  : 'assets/icons/green_bookmark.svg',
+          color: item.scrapedByMe ? AppColors.primary700 : AppColors.gray800,
+          label: item.scrapCount.toString(),
+          onTap: onTapScrap,
+          iconSize: 14,
+          labelStyle: AppTextStyles.bodyBody3M,
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  final Widget child;
+  final VoidCallback? onTap;
+
+  const _ActionButton({required this.child, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/onlywan/diary_item.dart
+++ b/lib/feature/community/widgets/onlywan/diary_item.dart
@@ -90,8 +90,8 @@ class _HeaderRow extends StatelessWidget {
           radius: 15,
           backgroundColor: AppColors.gray200,
           backgroundImage:
-              item.thumbImageUrl != null
-                  ? NetworkImage(item.thumbImageUrl!)
+              item.profileUrl != null
+                  ? NetworkImage(item.profileUrl!)
                   : null,
         ),
         const SizedBox(width: 8),

--- a/lib/feature/community/widgets/onlywan/diary_list.dart
+++ b/lib/feature/community/widgets/onlywan/diary_list.dart
@@ -1,25 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:inninglog/feature/community/model/diary_item.dart';
 import 'package:inninglog/feature/community/widgets/onlywan/diary_item.dart';
-import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/feature/community/widgets/shared/board_list.dart';
+import 'package:inninglog/shared/widgets/empty_state.dart';
 
 class FeedList extends StatelessWidget {
   final List<DiaryItemModel> items;
+  final bool isLoading;
+  final bool hasNext;
+  final Future<void> Function()? onLoadMore;
 
-  const FeedList({super.key, required this.items});
+  const FeedList({
+    super.key,
+    required this.items,
+    this.isLoading = false,
+    this.hasNext = false,
+    this.onLoadMore,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      itemBuilder: (context, index) {
-        final item = items[index];
-        return FeedItem(item: item);
-      },
-      separatorBuilder:
-          (_, __) =>
-              const Divider(height: 1, thickness: 1, color: AppColors.gray200),
-      itemCount: items.length,
+    if (items.isEmpty && !isLoading) {
+      return const EmptyState(message: '게시물이 없습니다.');
+    }
+
+    return BoardList<DiaryItemModel>(
+      items: items,
+      hasNext: hasNext,
+      isLoading: isLoading,
+      onLoadMore: onLoadMore,
+      itemBuilder: (context, item) => FeedItem(item: item),
     );
   }
 }

--- a/lib/feature/community/widgets/onlywan/diary_list.dart
+++ b/lib/feature/community/widgets/onlywan/diary_list.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/model/diary_item.dart';
+import 'package:inninglog/feature/community/widgets/onlywan/diary_item.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+
+class FeedList extends StatelessWidget {
+  final List<DiaryItemModel> items;
+
+  const FeedList({super.key, required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemBuilder: (context, index) {
+        final item = items[index];
+        return FeedItem(item: item);
+      },
+      separatorBuilder:
+          (_, __) =>
+              const Divider(height: 1, thickness: 1, color: AppColors.gray200),
+      itemCount: items.length,
+    );
+  }
+}

--- a/lib/feature/community/widgets/post/post_action_counts.dart
+++ b/lib/feature/community/widgets/post/post_action_counts.dart
@@ -5,21 +5,23 @@ import 'package:inninglog/shared/theme/app_text_styles.dart';
 
 // ---------- public components ----------
 
-enum CountVariant { primary, neutral }
+enum CountVariant { primary, neutral, black }
 
 class LikeCount extends StatelessWidget {
   final int count;
   final CountVariant variant;
+  final String? assetPathOverride;
   const LikeCount({
     required this.count,
     this.variant = CountVariant.primary,
+    this.assetPathOverride,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
     return _IconCount(
-      assetPath: 'assets/icons/green_heart.svg',
+      assetPath: assetPathOverride ?? 'assets/icons/green_heart.svg',
       count: count,
       variant: variant,
       iconWidth: 12.3,
@@ -52,16 +54,18 @@ class CommentCount extends StatelessWidget {
 class ScrapCount extends StatelessWidget {
   final int count;
   final CountVariant variant;
+  final String? assetPathOverride;
   const ScrapCount({
     required this.count,
     this.variant = CountVariant.primary,
+    this.assetPathOverride,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
     return _IconCount(
-      assetPath: 'assets/icons/green_bookmark.svg',
+      assetPath: assetPathOverride ?? 'assets/icons/green_bookmark.svg',
       count: count,
       variant: variant,
       iconWidth: 12.8,
@@ -91,10 +95,8 @@ class _IconCount extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color =
-        variant == CountVariant.neutral
-            ? AppColors.gray800
-            : AppColors.primary700;
+    final iconColor = _iconColor(variant);
+    final textColor = _textColor(variant);
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -103,14 +105,39 @@ class _IconCount extends StatelessWidget {
           width: iconWidth,
           height: iconHeight,
           // 단색 틴트
-          colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
+          colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
         ),
         SizedBox(width: 4),
         SizedBox(
           width: 32,
-          child: Text('$count', style: _baseTextStyle.copyWith(color: color)),
+          child: Text(
+            '$count',
+            style: _baseTextStyle.copyWith(color: textColor),
+          ),
         ),
       ],
     );
+  }
+}
+
+Color _iconColor(CountVariant variant) {
+  switch (variant) {
+    case CountVariant.neutral:
+      return AppColors.gray800;
+    case CountVariant.black:
+      return AppColors.primary700;
+    case CountVariant.primary:
+      return AppColors.primary700;
+  }
+}
+
+Color _textColor(CountVariant variant) {
+  switch (variant) {
+    case CountVariant.neutral:
+      return AppColors.gray800;
+    case CountVariant.black:
+      return AppColors.gray800;
+    case CountVariant.primary:
+      return AppColors.primary700;
   }
 }

--- a/lib/feature/community/widgets/post_detail/post_action_bar.dart
+++ b/lib/feature/community/widgets/post_detail/post_action_bar.dart
@@ -44,10 +44,10 @@ class PostActionBar extends StatelessWidget {
             child: Center(
               child: PostActionButton(
                 asset: 'assets/icons/board_heart.svg',
-                color: likeActive ? AppColors.primary700 : AppColors.gray500,
+                color: likeActive ? AppColors.primary700 : AppColors.gray400,
                 label: _labelWithCount('공감', likeCount),
                 onTap: onTapLike,
-                iconSize: 18,
+                iconSize: 16,
               ),
             ),
           ),
@@ -57,10 +57,10 @@ class PostActionBar extends StatelessWidget {
             child: Center(
               child: PostActionButton(
                 asset: 'assets/icons/board_comment.svg',
-                color: AppColors.gray500,
+                color: AppColors.gray400,
                 label: _labelWithCount('댓글', commentCount),
                 onTap: null,
-                iconSize: 18,
+                iconSize: 16,
               ),
             ),
           ),
@@ -70,10 +70,10 @@ class PostActionBar extends StatelessWidget {
             child: Center(
               child: PostActionButton(
                 asset: 'assets/icons/board_scrap.svg',
-                color: scrapActive ? AppColors.primary700 : AppColors.gray500,
+                color: scrapActive ? AppColors.primary700 : AppColors.gray400,
                 label: _labelWithCount('스크랩', scrapCount),
                 onTap: onTapScrap,
-                iconSize: 18,
+                iconSize: 16,
               ),
             ),
           ),

--- a/lib/feature/community/widgets/post_detail/post_action_button.dart
+++ b/lib/feature/community/widgets/post_detail/post_action_button.dart
@@ -8,6 +8,7 @@ class PostActionButton extends StatelessWidget {
   final Color color;
   final VoidCallback? onTap;
   final double iconSize;
+  final TextStyle? labelStyle;
 
   const PostActionButton({
     super.key,
@@ -16,10 +17,13 @@ class PostActionButton extends StatelessWidget {
     required this.color,
     required this.onTap,
     this.iconSize = 18,
+    this.labelStyle,
   });
 
   @override
   Widget build(BuildContext context) {
+    final resolvedLabelStyle =
+        (labelStyle ?? AppTextStyles.headHead8Sb).copyWith(color: color);
     final content = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -30,7 +34,7 @@ class PostActionButton extends StatelessWidget {
           colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
         ),
         const SizedBox(width: 4),
-        Text(label, style: AppTextStyles.headHead8Sb.copyWith(color: color)),
+        Text(label, style: resolvedLabelStyle),
       ],
     );
 

--- a/lib/feature/community/widgets/shared/board_header_bar.dart
+++ b/lib/feature/community/widgets/shared/board_header_bar.dart
@@ -7,20 +7,28 @@ import 'package:inninglog/shared/theme/app_text_styles.dart';
 class BoardHeaderBar extends StatelessWidget implements PreferredSizeWidget {
   /// 중앙에 표시할 메인 타이틀 텍스트.
   final String title;
+
   /// 타이틀 하단에 표시할 서브타이틀 텍스트.
   final String subtitle;
+
   /// 좌측 아이콘의 SVG 에셋 경로.
   final String leadingIconAsset;
+
   /// 좌측 아이콘 크기.
   final Size leadingIconSize;
+
   /// 좌측 아이콘 탭 콜백.
   final VoidCallback onTapLeading;
+
   /// 우측에 배치할 커스텀 위젯(없으면 좌측 폭과 동일한 여백).
   final Widget? trailing;
+
   /// 헤더 전체 높이.
   final double height;
+
   /// 좌측 아이콘 영역의 고정 폭.
   final double leadingWidth;
+
   /// 헤더 배경색.
   final Color backgroundColor;
 
@@ -67,7 +75,7 @@ class BoardHeaderBar extends StatelessWidget implements PreferredSizeWidget {
               children: [
                 Text(
                   title,
-                  style: AppTextStyles.headHead4EB.copyWith(
+                  style: AppTextStyles.headHead6B.copyWith(
                     color: AppColors.gray900,
                   ),
                 ),

--- a/lib/shared/theme/app_text_styles.dart
+++ b/lib/shared/theme/app_text_styles.dart
@@ -154,6 +154,13 @@ class AppTextStyles {
     height: 1,
     letterSpacing: -0.16,
   );
+  static const TextStyle headHead6_5M = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 15,
+    fontWeight: FontWeight.w500,
+    height: 1,
+    letterSpacing: -0.16,
+  );
 
   static const TextStyle headHead7R = TextStyle(
     fontFamily: "Pretendard",


### PR DESCRIPTION
## 🎯요약(Summary)
- 게시판 오직완 탭에서 직관일지 아이템/리스트 위젯 구현 및 API 연동 

## 💻 상세 내용(Describe your changes)
- 오직완 직관일지 아이템/리스트 위젯 구현
- 공개 직관일지 조회 무한 스크롤 API 연동 

## 📸 스크린
<img width="300"  alt="스크린샷, 2026-02-04 오후 9 03 52" src="https://github.com/user-attachments/assets/f0797e93-1385-4491-96bc-02e63d1b3148" />
샷

## 📌 관련 이슈번호(Related Issue)
- closed: #94 

## ✅ TODO
