### PR TITLE
[FIX] 게시글 카드 썸네일 로직 연동 시 403 에러 처리 

### DIFF
--- a/lib/feature/community/widgets/onlywan/diary_item.dart
+++ b/lib/feature/community/widgets/onlywan/diary_item.dart
@@ -4,6 +4,7 @@ import 'package:inninglog/feature/community/model/diary_item.dart';
 import 'package:inninglog/feature/community/widgets/post_detail/post_action_button.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
 import 'package:inninglog/shared/theme/app_text_styles.dart';
+import 'package:inninglog/shared/utils/image_url_utils.dart';
 
 enum FeedImageRatio { ratio3x4, ratio1x1, ratio4x3 }
 
@@ -46,10 +47,7 @@ class DiaryItem extends StatelessWidget {
                   child:
                       item.thumbImageUrl == null
                           ? Container(color: const Color(0xFFD9D9D9))
-                          : Image.network(
-                            item.thumbImageUrl!,
-                            fit: BoxFit.cover,
-                          ),
+                          : _DiaryThumbImage(imageUrl: item.thumbImageUrl!),
                 ),
               ),
 
@@ -71,6 +69,67 @@ class DiaryItem extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _DiaryThumbImage extends StatefulWidget {
+  final String imageUrl;
+
+  const _DiaryThumbImage({required this.imageUrl});
+
+  @override
+  State<_DiaryThumbImage> createState() => _DiaryThumbImageState();
+}
+
+class _DiaryThumbImageState extends State<_DiaryThumbImage> {
+  late String _currentImageUrl;
+  bool _triedOriginalFallback = false;
+  bool _fallbackScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentImageUrl = widget.imageUrl;
+  }
+
+  @override
+  void didUpdateWidget(covariant _DiaryThumbImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imageUrl != widget.imageUrl) {
+      _currentImageUrl = widget.imageUrl;
+      _triedOriginalFallback = false;
+      _fallbackScheduled = false;
+    }
+  }
+
+  void _fallbackToOriginalIfNeeded(Object error) {
+    if (_triedOriginalFallback || _fallbackScheduled) return;
+    if (error is! NetworkImageLoadException || error.statusCode != 403) return;
+
+    final originalUrl = originalImageUrlFromThumb(widget.imageUrl);
+    if (originalUrl == null || originalUrl == _currentImageUrl) return;
+
+    _fallbackScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {
+        _currentImageUrl = originalUrl;
+        _triedOriginalFallback = true;
+        _fallbackScheduled = false;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.network(
+      _currentImageUrl,
+      fit: BoxFit.cover,
+      errorBuilder: (context, error, stackTrace) {
+        _fallbackToOriginalIfNeeded(error);
+        return Container(color: const Color(0xFFD9D9D9));
+      },
     );
   }
 }

--- a/lib/feature/community/widgets/post/post_item_card.dart
+++ b/lib/feature/community/widgets/post/post_item_card.dart
@@ -3,6 +3,7 @@ import 'package:inninglog/feature/community/model/community_post.dart';
 import 'package:inninglog/feature/community/widgets/post/post_action_counts.dart';
 import 'package:inninglog/feature/community/widgets/post/post_texts.dart';
 import 'package:inninglog/shared/theme/app_text_styles.dart';
+import 'package:inninglog/shared/utils/image_url_utils.dart';
 
 import 'package:inninglog/shared/utils/date_time_utils.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
@@ -90,9 +91,9 @@ class PostItemCard extends StatelessWidget {
 
               const SizedBox(width: 10),
 
-              if (item.images.isNotEmpty)
+              if (item.thumbImageUrl != null && item.thumbImageUrl!.isNotEmpty)
                 ImageThumbnailWithBadge(
-                  imageUrl: item.images.first.url,
+                  imageUrl: item.thumbImageUrl!,
                   imageCount: item.imageCount ?? 0,
                 ),
             ],
@@ -103,7 +104,7 @@ class PostItemCard extends StatelessWidget {
   }
 }
 
-class ImageThumbnailWithBadge extends StatelessWidget {
+class ImageThumbnailWithBadge extends StatefulWidget {
   final String imageUrl;
   final int imageCount;
 
@@ -112,6 +113,50 @@ class ImageThumbnailWithBadge extends StatelessWidget {
     required this.imageUrl,
     required this.imageCount,
   });
+
+  @override
+  State<ImageThumbnailWithBadge> createState() =>
+      _ImageThumbnailWithBadgeState();
+}
+
+class _ImageThumbnailWithBadgeState extends State<ImageThumbnailWithBadge> {
+  late String _currentImageUrl;
+  bool _triedOriginalFallback = false;
+  bool _fallbackScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentImageUrl = widget.imageUrl;
+  }
+
+  @override
+  void didUpdateWidget(covariant ImageThumbnailWithBadge oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imageUrl != widget.imageUrl) {
+      _currentImageUrl = widget.imageUrl;
+      _triedOriginalFallback = false;
+      _fallbackScheduled = false;
+    }
+  }
+
+  void _fallbackToOriginalIfNeeded(Object error) {
+    if (_triedOriginalFallback || _fallbackScheduled) return;
+    if (error is! NetworkImageLoadException || error.statusCode != 403) return;
+
+    final originalUrl = originalImageUrlFromThumb(widget.imageUrl);
+    if (originalUrl == null || originalUrl == _currentImageUrl) return;
+
+    _fallbackScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {
+        _currentImageUrl = originalUrl;
+        _triedOriginalFallback = true;
+        _fallbackScheduled = false;
+      });
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -124,12 +169,19 @@ class ImageThumbnailWithBadge extends StatelessWidget {
             height: 85,
             color: const Color(0xFFE5E7EB),
             child:
-                imageUrl.isEmpty
+                _currentImageUrl.isEmpty
                     ? null
-                    : Image.network(imageUrl, fit: BoxFit.cover),
+                    : Image.network(
+                      _currentImageUrl,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) {
+                        _fallbackToOriginalIfNeeded(error);
+                        return const SizedBox.expand();
+                      },
+                    ),
           ),
         ),
-        if (imageCount > 0)
+        if (widget.imageCount > 1)
           Positioned(
             right: 4,
             bottom: 4,
@@ -140,7 +192,7 @@ class ImageThumbnailWithBadge extends StatelessWidget {
                 borderRadius: BorderRadius.circular(4),
               ),
               child: Text(
-                '$imageCount',
+                '${widget.imageCount}',
                 style: AppTextStyles.headHead8Sb.copyWith(
                   color: AppColors.gray300,
                 ),

--- a/lib/feature/community/widgets/root/components/popular_post_card.dart
+++ b/lib/feature/community/widgets/root/components/popular_post_card.dart
@@ -4,6 +4,7 @@ import 'package:inninglog/feature/community/widgets/post/post_action_counts.dart
 import 'package:inninglog/feature/community/widgets/post/post_texts.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
 import 'package:inninglog/shared/utils/date_time_utils.dart';
+import 'package:inninglog/shared/utils/image_url_utils.dart';
 
 class PopularPostCard extends StatelessWidget {
   final PostBase post;
@@ -57,14 +58,14 @@ class PopularPostCard extends StatelessWidget {
                 ],
               ),
             ),
-            if (post.thumbImageUrl != null && post.thumbImageUrl!.isNotEmpty)
-              ...[
-                const SizedBox(width: 10),
-                _ThumbImage(
-                  imageUrl: post.thumbImageUrl!,
-                  imageCount: post.imageCount,
-                ),
-              ],
+            if (post.thumbImageUrl != null &&
+                post.thumbImageUrl!.isNotEmpty) ...[
+              const SizedBox(width: 10),
+              _ThumbImage(
+                imageUrl: post.thumbImageUrl!,
+                imageCount: post.imageCount,
+              ),
+            ],
           ],
         ),
       ),
@@ -72,11 +73,54 @@ class PopularPostCard extends StatelessWidget {
   }
 }
 
-class _ThumbImage extends StatelessWidget {
+class _ThumbImage extends StatefulWidget {
   final String imageUrl;
   final int imageCount;
 
   const _ThumbImage({required this.imageUrl, required this.imageCount});
+
+  @override
+  State<_ThumbImage> createState() => _ThumbImageState();
+}
+
+class _ThumbImageState extends State<_ThumbImage> {
+  late String _currentImageUrl;
+  bool _triedOriginalFallback = false;
+  bool _fallbackScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentImageUrl = widget.imageUrl;
+  }
+
+  @override
+  void didUpdateWidget(covariant _ThumbImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imageUrl != widget.imageUrl) {
+      _currentImageUrl = widget.imageUrl;
+      _triedOriginalFallback = false;
+      _fallbackScheduled = false;
+    }
+  }
+
+  void _fallbackToOriginalIfNeeded(Object error) {
+    if (_triedOriginalFallback || _fallbackScheduled) return;
+    if (error is! NetworkImageLoadException || error.statusCode != 403) return;
+
+    final originalUrl = originalImageUrlFromThumb(widget.imageUrl);
+    if (originalUrl == null || originalUrl == _currentImageUrl) return;
+
+    _fallbackScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {
+        _currentImageUrl = originalUrl;
+        _triedOriginalFallback = true;
+        _fallbackScheduled = false;
+      });
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -85,7 +129,14 @@ class _ThumbImage extends StatelessWidget {
       child: SizedBox(
         width: 64,
         height: 64,
-        child: Image.network(imageUrl, fit: BoxFit.cover),
+        child: Image.network(
+          _currentImageUrl,
+          fit: BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) {
+            _fallbackToOriginalIfNeeded(error);
+            return const SizedBox.expand();
+          },
+        ),
       ),
     );
   }

--- a/lib/shared/utils/image_url_utils.dart
+++ b/lib/shared/utils/image_url_utils.dart
@@ -1,0 +1,13 @@
+String? originalImageUrlFromThumb(String? url) {
+  if (url == null || url.isEmpty) return null;
+
+  final uri = Uri.tryParse(url);
+  if (uri == null) return null;
+
+  final pathSegments = List<String>.from(uri.pathSegments);
+  final thumbIndex = pathSegments.indexOf('thumb');
+  if (thumbIndex < 0) return null;
+
+  pathSegments.removeAt(thumbIndex);
+  return uri.replace(pathSegments: pathSegments).toString();
+}


### PR DESCRIPTION
## 🎯요약(Summary)
- Post 생성 직후 게시글 목록을 리페치하면서 썸네일 이미지를 읽을 때 403 에러가 나는 이슈 해결 

## 💻 상세 내용(Describe your changes)
- 403에러 시 썸네일 경로가 아닌 실제 원본 이미지에 접근해서 띄울 수 있도록 공통 함수 추가 

## 📸 스크린샷
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/2437e7ff-fe83-4ba0-b20a-2a5688e73666" />

## 📌 관련 이슈번호(Related Issue)
- closed: #116 
