### PR TITLE
[FEAT] 커뮤니티 오늘의 뉴스 화면 구성

### DIFF
--- a/lib/feature/community/screens/tabs/news_tab.dart
+++ b/lib/feature/community/screens/tabs/news_tab.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/data/team_catalog.dart';
+import 'package:inninglog/feature/community/widgets/news/news_card.dart';
+import 'package:inninglog/feature/community/widgets/news/news_section.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+
+class NewsTab extends StatelessWidget {
+  final String teamCode;
+
+  const NewsTab({super.key, required this.teamCode});
+
+  String get _teamHighlightText {
+    if (teamCode == 'ALL') return '전체';
+    final label = kboTeamLabelOf(teamCode);
+    final sanitized = label.replaceAll(RegExp(r'[^0-9A-Za-z가-힣 ]'), '').trim();
+    return sanitized.replaceAll(' ', '');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.primary50,
+      child: ListView(
+        padding: const EdgeInsets.only(top: 20, bottom: 24),
+        children: [
+          _TeamNewsSection(highlightText: _teamHighlightText),
+          SizedBox(height: 32),
+          const _KboNewsSection(),
+        ],
+      ),
+    );
+  }
+}
+
+class _TeamNewsSection extends StatelessWidget {
+  final String highlightText;
+
+  const _TeamNewsSection({required this.highlightText});
+
+  static const _items = <NewsCardItemData>[
+    NewsCardItemData(
+      title: '두산, 최근 10년 FA 지출 1위 기록',
+      summaryBullets: [
+        '두산, 최근 10년 FA 시장에서 830억 원 지출로 1위',
+        '내부 핵심 선수 재계약 + 박찬호 영입 등 공격적 투자 기조',
+      ],
+      tags: ['FA시장', '박찬호'],
+    ),
+    NewsCardItemData(
+      title: '두산, 최근 10년 FA 지출 1위 기록',
+      summaryBullets: [
+        '두산, 최근 10년 FA 시장에서 830억 원 지출로 1위',
+        '내부 핵심 선수 재계약 + 박찬호 영입 등 공격적 투자 기조',
+      ],
+      tags: ['FA시장', '박찬호'],
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return NewsSection(
+      highlightText: highlightText,
+      showInfoIcon: true,
+      items: _items,
+    );
+  }
+}
+
+class _KboNewsSection extends StatelessWidget {
+  const _KboNewsSection();
+
+  static const _items = <NewsCardItemData>[
+    NewsCardItemData(
+      title: '토론토, 폰세 영입으로 ‘KBO 파이프라인’ 본격 가동',
+      summaryBullets: [
+        '토론토, KBO MVP 코디 폰세와 3년 3,000만 달러 계약...KBO 출신 영입 확대',
+        '라우어 성공·문서준 영입 등 사례 누적되며 KBO 시장을 새로운 전력 루트로 활용',
+      ],
+      tags: ['FA시장', '박찬호'],
+    ),
+    NewsCardItemData(
+      title: '두산, 최근 10년 FA 지출 1위 기록',
+      summaryBullets: [
+        '두산, 최근 10년 FA 시장에서 830억 원 지출로 1위',
+        '내부 핵심 선수 재계약 + 박찬호 영입 등 공격적 투자 기조',
+      ],
+      tags: ['FA시장', '박찬호'],
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return const NewsSection(highlightText: 'KBO', items: _items);
+  }
+}

--- a/lib/feature/community/screens/tabs/news_tab.dart
+++ b/lib/feature/community/screens/tabs/news_tab.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:inninglog/feature/community/data/team_catalog.dart';
+import 'package:inninglog/feature/community/widgets/news/news_ai_summary_bottom_sheet.dart';
 import 'package:inninglog/feature/community/widgets/news/news_card.dart';
 import 'package:inninglog/feature/community/widgets/news/news_section.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
@@ -62,6 +63,7 @@ class _TeamNewsSection extends StatelessWidget {
       highlightText: highlightText,
       showInfoIcon: true,
       items: _items,
+      onTapInfo: () => showNewsAiSummaryBottomSheet(context),
     );
   }
 }
@@ -90,6 +92,10 @@ class _KboNewsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const NewsSection(highlightText: 'KBO', items: _items);
+    return NewsSection(
+      highlightText: 'KBO',
+      items: _items,
+      onTapMore: () => showNewsAiSummaryBottomSheet(context),
+    );
   }
 }

--- a/lib/feature/community/screens/teamboard_page.dart
+++ b/lib/feature/community/screens/teamboard_page.dart
@@ -7,6 +7,7 @@ import 'package:inninglog/router/app_routes.dart';
 import 'package:inninglog/shared/theme/app_colors.dart';
 import 'package:inninglog/shared/widgets/common_header.dart';
 import 'tabs/free_board_tab.dart';
+import 'tabs/news_tab.dart';
 import 'tabs/onlywan_tab.dart';
 
 enum BoardMode { normal, myPosts, myComments, scraps, popular }
@@ -185,7 +186,7 @@ class _TeamBoardPageState extends State<TeamBoardPage>
                         mode: widget.mode,
                       );
                     case BoardTab.news:
-                      return const Center(child: Text('오늘의 뉴스'));
+                      return NewsTab(teamCode: widget.teamCode ?? 'ALL');
                   }
                 }),
               ),

--- a/lib/feature/community/widgets/news/news_ai_summary_bottom_sheet.dart
+++ b/lib/feature/community/widgets/news/news_ai_summary_bottom_sheet.dart
@@ -1,0 +1,123 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+Future<T?> showNewsAiSummaryBottomSheet<T>(BuildContext context) {
+  return showModalBottomSheet<T>(
+    context: context,
+    useRootNavigator: true,
+    isScrollControlled: false,
+    enableDrag: true,
+    isDismissible: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: AppColors.gray900.withValues(alpha: 0.75),
+    builder: (_) => const _NewsAiSummaryBottomSheet(),
+  );
+}
+
+class _NewsAiSummaryBottomSheet extends StatelessWidget {
+  const _NewsAiSummaryBottomSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.paddingOf(context).bottom;
+    final bottomSpacing = math.max(20.0, bottomInset + 8);
+
+    return SafeArea(
+      top: false,
+      bottom: false,
+      child: Container(
+        width: double.infinity,
+        padding: EdgeInsets.fromLTRB(20, 14, 20, bottomSpacing),
+        decoration: const BoxDecoration(
+          color: AppColors.primary50,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+          boxShadow: [
+            BoxShadow(
+              color: Color(0x40000000),
+              blurRadius: 4,
+              offset: Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                width: 43,
+                height: 3,
+                decoration: BoxDecoration(
+                  color: AppColors.gray500,
+                  borderRadius: BorderRadius.circular(100),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'AI로 기사를 요약했어요',
+              style: AppTextStyles.bodyBody1Sb.copyWith(
+                color: AppColors.gray900,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _bulletText('응원팀과 관련된 주요 소식을 요약했어요.'),
+            const SizedBox(height: 2),
+            _bulletText('전체 맥락을 이해하기 위해선 원문 보기를 권장해요.'),
+            const SizedBox(height: 18),
+            SizedBox(
+              width: double.infinity,
+              height: 54,
+              child: FilledButton(
+                onPressed: () => Navigator.of(context).pop(),
+                style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.primary700,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(36),
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                ),
+                child: Text(
+                  '확인했어요',
+                  style: AppTextStyles.headHead6B.copyWith(color: Colors.white),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _bulletText(String text) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '•',
+          style: AppTextStyles.bodyBody2M.copyWith(
+            color: AppColors.gray850,
+            height: 24 / 14,
+          ),
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            text,
+            style: AppTextStyles.bodyBody2M.copyWith(
+              color: AppColors.gray850,
+              height: 24 / 14,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/feature/community/widgets/news/news_bullet_list.dart
+++ b/lib/feature/community/widgets/news/news_bullet_list.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+class NewsBulletList extends StatelessWidget {
+  final List<String> items;
+
+  const NewsBulletList({super.key, required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: List.generate(items.length, (index) {
+        final isLast = index == items.length - 1;
+        return Padding(
+          padding: EdgeInsets.only(bottom: isLast ? 0 : 2),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 1),
+                child: Text(
+                  '•',
+                  style: AppTextStyles.bodyBody3Rg.copyWith(
+                    color: AppColors.gray850,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  items[index],
+                  style: AppTextStyles.bodyBody3Rg.copyWith(
+                    color: AppColors.gray850,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/feature/community/widgets/news/news_card.dart
+++ b/lib/feature/community/widgets/news/news_card.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/widgets/news/news_bullet_list.dart';
+import 'package:inninglog/feature/community/widgets/news/news_tag_chip.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+class NewsCardItemData {
+  final String title;
+  final List<String> summaryBullets;
+  final List<String> tags;
+
+  const NewsCardItemData({
+    required this.title,
+    required this.summaryBullets,
+    required this.tags,
+  });
+}
+
+class NewsCard extends StatelessWidget {
+  final NewsCardItemData item;
+  final VoidCallback? onTap;
+
+  const NewsCard({super.key, required this.item, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
+          decoration: BoxDecoration(
+            color: AppColors.primary50,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: AppColors.gray300, width: 0.7),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                item.title,
+                style: AppTextStyles.headHead7Sb.copyWith(
+                  color: AppColors.gray850,
+                ),
+              ),
+              const SizedBox(height: 8),
+              NewsBulletList(items: item.summaryBullets),
+              if (item.tags.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 4,
+                  runSpacing: 4,
+                  children: item.tags
+                      .map((tag) => NewsTagChip(label: tag))
+                      .toList(growable: false),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/news/news_cards_panel.dart
+++ b/lib/feature/community/widgets/news/news_cards_panel.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/widgets/news/news_card.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+
+class NewsCardsPanel extends StatelessWidget {
+  final List<NewsCardItemData> items;
+  final void Function(NewsCardItemData item)? onTapItem;
+
+  const NewsCardsPanel({super.key, required this.items, this.onTapItem});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+      decoration: BoxDecoration(
+        color: AppColors.primary100,
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.gray900.withValues(alpha: 0.1),
+            blurRadius: 6,
+            offset: const Offset(2, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        children: List.generate(items.length, (index) {
+          final item = items[index];
+          final isLast = index == items.length - 1;
+          return Padding(
+            padding: EdgeInsets.only(bottom: isLast ? 0 : 12),
+            child: NewsCard(item: item, onTap: () => onTapItem?.call(item)),
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/news/news_section.dart
+++ b/lib/feature/community/widgets/news/news_section.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/feature/community/widgets/news/news_card.dart';
+import 'package:inninglog/feature/community/widgets/news/news_cards_panel.dart';
+import 'package:inninglog/feature/community/widgets/news/news_section_header.dart';
+
+class NewsSection extends StatelessWidget {
+  final String highlightText;
+  final bool showInfoIcon;
+  final List<NewsCardItemData> items;
+  final VoidCallback? onTapMore;
+  final VoidCallback? onTapInfo;
+  final void Function(NewsCardItemData item)? onTapItem;
+
+  const NewsSection({
+    super.key,
+    required this.highlightText,
+    required this.items,
+    this.showInfoIcon = false,
+    this.onTapMore,
+    this.onTapInfo,
+    this.onTapItem,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: NewsSectionHeader(
+            highlightText: highlightText,
+            showInfoIcon: showInfoIcon,
+            onTapMore: onTapMore,
+            onTapInfo: onTapInfo,
+          ),
+        ),
+        const SizedBox(height: 12),
+        NewsCardsPanel(items: items, onTapItem: onTapItem),
+      ],
+    );
+  }
+}

--- a/lib/feature/community/widgets/news/news_section_header.dart
+++ b/lib/feature/community/widgets/news/news_section_header.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+class NewsSectionHeader extends StatelessWidget {
+  final String highlightText;
+  final bool showInfoIcon;
+  final VoidCallback? onTapMore;
+  final VoidCallback? onTapInfo;
+
+  const NewsSectionHeader({
+    super.key,
+    required this.highlightText,
+    this.showInfoIcon = false,
+    this.onTapMore,
+    this.onTapInfo,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final titleStyle = AppTextStyles.headHead6Sb.copyWith(
+      color: AppColors.gray850,
+    );
+
+    return SizedBox(
+      height: 21,
+      child: Row(
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                Flexible(
+                  child: RichText(
+                    overflow: TextOverflow.ellipsis,
+                    text: TextSpan(
+                      style: titleStyle,
+                      children: [
+                        TextSpan(
+                          text: highlightText,
+                          style: titleStyle.copyWith(
+                            color: AppColors.primary700,
+                          ),
+                        ),
+                        const TextSpan(text: ' 오늘의 뉴스 by '),
+                        TextSpan(
+                          text: 'AI',
+                          style: titleStyle.copyWith(
+                            color: AppColors.primary700,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                if (showInfoIcon) ...[
+                  const SizedBox(width: 4),
+                  InkWell(
+                    onTap: onTapInfo,
+                    borderRadius: BorderRadius.circular(12),
+                    child: const Icon(
+                      Icons.info_outline,
+                      size: 15,
+                      color: AppColors.gray500,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          InkWell(
+            onTap: onTapMore,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Row(
+                children: [
+                  Text(
+                    '더보기',
+                    style: AppTextStyles.headHead8M.copyWith(
+                      color: AppColors.gray500,
+                    ),
+                  ),
+                  const SizedBox(width: 1),
+                  const Icon(
+                    Icons.chevron_right,
+                    size: 16,
+                    color: AppColors.gray500,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/community/widgets/news/news_tag_chip.dart
+++ b/lib/feature/community/widgets/news/news_tag_chip.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:inninglog/shared/theme/app_colors.dart';
+import 'package:inninglog/shared/theme/app_text_styles.dart';
+
+class NewsTagChip extends StatelessWidget {
+  final String label;
+
+  const NewsTagChip({super.key, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: AppColors.primary50,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.primary700, width: 0.7),
+      ),
+      child: Text(
+        label,
+        style: AppTextStyles.bodyBody4M.copyWith(color: AppColors.gray850),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
🎯요약(Summary)
- 오늘의 뉴스 탭 UI를 구현하고, 더보기 클릭 시 AI 요약 안내 바텀시트를 추가했습니다. 

💻 상세 내용(Describe your changes)

- TeamBoardPage에서 BoardTab.news를 실제 NewsTab으로 연결
- 뉴스 탭 공통 UI 컴포넌트 분리 및 재사용 구조 적용
   - news_section, news_section_header, news_cards_panel, news_card, news_bullet_list, news_tag_chip
- onTapInfo 시 노출되는 AI 요약 바텀시트 구현
- 바텀시트 인터랙션 처리
   - 확인했어요 버튼 탭 시 닫힘
   - 바텀시트 바깥 터치 시 닫힘 (isDismissible: true)
  - 드래그 닫기 허용 (enableDrag: true)

## 📸 스크린샷

<img width="300" alt="IMG_6049" src="https://github.com/user-attachments/assets/92e49fbd-784f-4e1e-a693-7ed9ea05886e" />

<img width="300" alt="IMG_6050" src="https://github.com/user-attachments/assets/ed8530a0-7c4a-4a4e-a355-554550ced30a" />

## 📌 관련 이슈번호(Related Issue)
- closed: #127 

## ✅ TODO
- [ ]  실제 뉴스 API 연동 및 더보기 원문 이동/리스트 페이지 연결